### PR TITLE
feat: impl default target with connection details in the function-kcl v0.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ env:
   XPKG: xpkg.upbound.io/${{ github.repository}}
 
   # The package version to push. The default is 0.0.0-gitsha.
-  XPKG_VERSION: v0.3.4
+  XPKG_VERSION: v0.4.0
 
 jobs:
   unit-test:

--- a/examples/default/connection_details/Makefile
+++ b/examples/default/connection_details/Makefile
@@ -1,0 +1,2 @@
+run:
+	crossplane beta render xr.yaml composition.yaml functions.yaml -r

--- a/examples/default/connection_details/README.md
+++ b/examples/default/connection_details/README.md
@@ -1,0 +1,113 @@
+# Example Manifests
+
+You can run your function locally and test it using `crossplane beta render`
+with these example manifests.
+
+```shell
+# Run the function locally
+$ go run . --insecure --debug
+```
+
+```shell
+# Then, in another terminal, call it with these example manifests
+$ crossplane beta render xr.yaml composition.yaml functions.yaml -r
+---
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+status:
+  dummy: cool-status
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: sample-access-key-1
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+  name: sample-access-key-1
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        testing.upbound.io/example-name: test-user-1
+  writeConnectionSecretToRef:
+    name: sample-access-key-secret-1
+    namespace: crossplane-system
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: test-user-0
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+    dummy: foo
+    testing.upbound.io/example-name: test-user-0
+  name: test-user-0
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider: {}
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: sample-access-key-0
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+  name: sample-access-key-0
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        testing.upbound.io/example-name: test-user-0
+  writeConnectionSecretToRef:
+    name: sample-access-key-secret-0
+    namespace: crossplane-system
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: test-user-1
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+    dummy: foo
+    testing.upbound.io/example-name: test-user-1
+  name: test-user-1
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider: {}
+```

--- a/examples/default/connection_details/composition.yaml
+++ b/examples/default/connection_details/composition.yaml
@@ -1,0 +1,71 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-template-go
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: normal
+    functionRef:
+      name: kcl-function
+    input:
+      apiVersion: krm.kcl.dev/v1alpha1
+      kind: KCLRun
+      metadata:
+        name: basic
+      spec:
+        source: |
+          import base64
+
+          oxr = option("params").oxr
+          count = oxr.spec.count or 1
+          ocds = option("params").ocds
+          dxr = {
+              **oxr
+              status.dummy = "cool-status"
+          }
+          details = {
+              apiVersion: "meta.krm.kcl.dev/v1alpha1"
+              kind: "CompositeConnectionDetails"
+              if "sample-access-key-0" in ocds:
+                  data: {
+                      username = ocds["sample-access-key-0"].ConnectionDetails.username
+                      password = ocds["sample-access-key-0"].ConnectionDetails.password
+                      url = base64.encode("http://www.example.com")
+                  }
+              else:
+                  data: {}
+          }
+          items = sum([[{
+              apiVersion: "iam.aws.upbound.io/v1beta1"
+              kind: "User"
+              metadata.name = "test-user-{}".format(i)
+              metadata.labels: {
+                  "testing.upbound.io/example-name" = "test-user-{}".format(i)
+                  if "test-user-{}".format(i) in ocds:
+                      dummy = ocds["test-user-{}".format(i)].Resource.metadata.labels.dummy
+                  else:
+                      dummy = "foo"
+              }
+              spec.forProvider: {}
+          }, {
+              apiVersion: "iam.aws.upbound.io/v1beta1"
+              kind: "AccessKey"
+              metadata.name = "sample-access-key-{}".format(i)
+              metadata.annotations: {
+                  "krm.kcl.dev/ready": "True"
+              }
+              spec.forProvider.userSelector.matchLabels: {
+                  "testing.upbound.io/example-name" = "test-user-{}".format(i)
+              }
+              spec.writeConnectionSecretToRef: {
+                  name: "sample-access-key-secret-{}".format(i)
+                  namespace: "crossplane-system"
+              }
+          }] for i in range(count)], []) + [
+              details
+              dxr
+          ]

--- a/examples/default/connection_details/composition.yaml
+++ b/examples/default/connection_details/composition.yaml
@@ -69,3 +69,19 @@ spec:
               details
               dxr
           ]
+
+  # Just for test
+  - step: normal1
+    functionRef:
+      name: kcl-function
+    input:
+      apiVersion: krm.kcl.dev/v1alpha1
+      kind: KCLRun
+      metadata:
+        name: show-dcds
+      spec:
+        source: |
+          {
+              metadata.name = "dcds"
+              dcds: option("params").dcds
+          }

--- a/examples/default/connection_details/composition.yaml
+++ b/examples/default/connection_details/composition.yaml
@@ -15,6 +15,8 @@ spec:
       apiVersion: krm.kcl.dev/v1alpha1
       kind: KCLRun
       metadata:
+        annotations:
+          "krm.kcl.dev/default_ready": "True"
         name: basic
       spec:
         source: |

--- a/examples/default/connection_details/functions.yaml
+++ b/examples/default/connection_details/functions.yaml
@@ -1,0 +1,9 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: kcl-function
+  annotations:
+    # This tells crossplane beta render to connect to the function locally.
+    render.crossplane.io/runtime: Development
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:latest

--- a/examples/default/connection_details/xr.yaml
+++ b/examples/default/connection_details/xr.yaml
@@ -1,0 +1,6 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec:
+  count: 1

--- a/examples/default/resources/Makefile
+++ b/examples/default/resources/Makefile
@@ -1,0 +1,2 @@
+run:
+	crossplane beta render xr.yaml composition.yaml functions.yaml -r

--- a/examples/default/resources/README.md
+++ b/examples/default/resources/README.md
@@ -1,0 +1,113 @@
+# Example Manifests
+
+You can run your function locally and test it using `crossplane beta render`
+with these example manifests.
+
+```shell
+# Run the function locally
+$ go run . --insecure --debug
+```
+
+```shell
+# Then, in another terminal, call it with these example manifests
+$ crossplane beta render xr.yaml composition.yaml functions.yaml -r
+---
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+status:
+  dummy: cool-status
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: sample-access-key-1
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+  name: sample-access-key-1
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        testing.upbound.io/example-name: test-user-1
+  writeConnectionSecretToRef:
+    name: sample-access-key-secret-1
+    namespace: crossplane-system
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: test-user-0
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+    dummy: foo
+    testing.upbound.io/example-name: test-user-0
+  name: test-user-0
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider: {}
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: sample-access-key-0
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+  name: sample-access-key-0
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        testing.upbound.io/example-name: test-user-0
+  writeConnectionSecretToRef:
+    name: sample-access-key-secret-0
+    namespace: crossplane-system
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: test-user-1
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+    dummy: foo
+    testing.upbound.io/example-name: test-user-1
+  name: test-user-1
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider: {}
+```

--- a/examples/default/resources/composition.yaml
+++ b/examples/default/resources/composition.yaml
@@ -1,0 +1,68 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-template-go
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: normal
+    functionRef:
+      name: kcl-function
+    input:
+      apiVersion: krm.kcl.dev/v1alpha1
+      kind: KCLRun
+      metadata:
+        name: basic
+      spec:
+        source: |
+          import base64
+
+          oxr = option("params").oxr
+          count = oxr.spec.count or 1
+          ocds = option("params").ocds
+          dxr = {
+              **oxr
+              status.dummy = "cool-status"
+          }
+          details = {
+              apiVersion: "meta.krm.kcl.dev/v1alpha1"
+              kind: "CompositeConnectionDetails"
+              if "sample-access-key-0" in ocds:
+                  data: {
+                      username = ocds["sample-access-key-0"].connectionDetails.username
+                      password = ocds["sample-access-key-0"].connectionDetails.password
+                      url = base64.encode("http://www.example.com")
+                  }
+              else:
+                  data: {}
+          }
+          items = sum([[{
+              apiVersion: "iam.aws.upbound.io/v1beta1"
+              kind: "User"
+              metadata.name = "test-user-{}".format(i)
+              metadata.labels: {
+                  "testing.upbound.io/example-name" = "test-user-{}".format(i)
+                  if "test-user-{}".format(i) in ocds:
+                      dummy = ocds["test-user-{}".format(i)].Resource.metadata.labels.dummy
+                  else:
+                      dummy = "foo"
+              }
+              spec.forProvider: {}
+          }, {
+              apiVersion: "iam.aws.upbound.io/v1beta1"
+              kind: "AccessKey"
+              metadata.name = "sample-access-key-{}".format(i)
+              spec.forProvider.userSelector.matchLabels: {
+                  "testing.upbound.io/example-name" = "test-user-{}".format(i)
+              }
+              spec.writeConnectionSecretToRef: {
+                  name: "sample-access-key-secret-{}".format(i)
+                  namespace: "crossplane-system"
+              }
+          }] for i in range(count)], []) + [
+              details
+              dxr
+          ]

--- a/examples/default/resources/composition.yaml
+++ b/examples/default/resources/composition.yaml
@@ -32,8 +32,8 @@ spec:
               kind: "CompositeConnectionDetails"
               if "sample-access-key-0" in ocds:
                   data: {
-                      username = ocds["sample-access-key-0"].connectionDetails.username
-                      password = ocds["sample-access-key-0"].connectionDetails.password
+                      username = ocds["sample-access-key-0"].ConnectionDetails.username
+                      password = ocds["sample-access-key-0"].ConnectionDetails.password
                       url = base64.encode("http://www.example.com")
                   }
               else:

--- a/examples/default/resources/functions.yaml
+++ b/examples/default/resources/functions.yaml
@@ -1,0 +1,9 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: kcl-function
+  annotations:
+    # This tells crossplane beta render to connect to the function locally.
+    render.crossplane.io/runtime: Development
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:latest

--- a/examples/default/resources/xr.yaml
+++ b/examples/default/resources/xr.yaml
@@ -1,0 +1,6 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec:
+  count: 2

--- a/examples/default/resources_without_xr/Makefile
+++ b/examples/default/resources_without_xr/Makefile
@@ -1,0 +1,2 @@
+run:
+	crossplane beta render xr.yaml composition.yaml functions.yaml -r

--- a/examples/default/resources_without_xr/README.md
+++ b/examples/default/resources_without_xr/README.md
@@ -1,0 +1,65 @@
+# Example Manifests
+
+You can run your function locally and test it using `crossplane beta render`
+with these example manifests.
+
+```shell
+# Run the function locally
+$ go run . --insecure --debug
+```
+
+```shell
+# Then, in another terminal, call it with these example manifests
+$ crossplane beta render xr.yaml composition.yaml functions.yaml -r
+---
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: test-user-0
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+    dummy: foo
+    testing.upbound.io/example-name: test-user-0
+  name: test-user-0
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider: {}
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: sample-access-key-0
+  generateName: example-
+  labels:
+    crossplane.io/composite: example
+  name: sample-access-key-0
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example
+    uid: ""
+spec:
+  forProvider:
+    userSelector:
+      matchLabels:
+        testing.upbound.io/example-name: test-user-0
+  writeConnectionSecretToRef:
+    name: sample-access-key-secret-0
+    namespace: crossplane-system
+```

--- a/examples/default/resources_without_xr/composition.yaml
+++ b/examples/default/resources_without_xr/composition.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-template-go
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: normal
+    functionRef:
+      name: kcl-function
+    input:
+      apiVersion: krm.kcl.dev/v1alpha1
+      kind: KCLRun
+      metadata:
+        name: basic
+      spec:
+        source: |
+          import base64
+
+          oxr = option("params").oxr
+          count = oxr.spec.count or 1
+          ocds = option("params").ocds
+          dxr = {
+              **oxr.meta
+              status.dummy = "cool-status"
+          }
+          details = {
+              apiVersion: "meta.krm.kcl.dev/v1alpha1"
+              kind: "CompositeConnectionDetails"
+              if "sample-access-key-0" in ocds:
+                  data: {
+                      username = ocds["sample-access-key-0"].connectionDetails.username
+                      password = ocds["sample-access-key-0"].connectionDetails.password
+                      url = base64.encode("http://www.example.com")
+                  }
+              else:
+                  data: {}
+          }
+          items = sum([[{
+              apiVersion: "iam.aws.upbound.io/v1beta1"
+              kind: "User"
+              metadata.name = "test-user-{}".format(i)
+              metadata.labels: {
+                  "testing.upbound.io/example-name" = "test-user-{}".format(i)
+                  if "test-user-{}".format(i) in ocds:
+                      dummy = ocds["test-user-{}".format(i)].Resource.metadata.labels.dummy
+                  else:
+                      dummy = "foo"
+              }
+              spec.forProvider: {}
+          }, {
+              apiVersion: "iam.aws.upbound.io/v1beta1"
+              kind: "AccessKey"
+              metadata.name = "sample-access-key-{}".format(i)
+              spec.forProvider.userSelector.matchLabels: {
+                  "testing.upbound.io/example-name" = "test-user-{}".format(i)
+              }
+              spec.writeConnectionSecretToRef: {
+                  name: "sample-access-key-secret-{}".format(i)
+                  namespace: "crossplane-system"
+              }
+          }] for i in range(count)], []) + [
+              details
+          ]

--- a/examples/default/resources_without_xr/composition.yaml
+++ b/examples/default/resources_without_xr/composition.yaml
@@ -32,8 +32,8 @@ spec:
               kind: "CompositeConnectionDetails"
               if "sample-access-key-0" in ocds:
                   data: {
-                      username = ocds["sample-access-key-0"].connectionDetails.username
-                      password = ocds["sample-access-key-0"].connectionDetails.password
+                      username = ocds["sample-access-key-0"].ConnectionDetails.username
+                      password = ocds["sample-access-key-0"].ConnectionDetails.password
                       url = base64.encode("http://www.example.com")
                   }
               else:

--- a/examples/default/resources_without_xr/functions.yaml
+++ b/examples/default/resources_without_xr/functions.yaml
@@ -1,0 +1,9 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: kcl-function
+  annotations:
+    # This tells crossplane beta render to connect to the function locally.
+    render.crossplane.io/runtime: Development
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:latest

--- a/examples/default/resources_without_xr/xr.yaml
+++ b/examples/default/resources_without_xr/xr.yaml
@@ -1,0 +1,6 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec:
+  count: 1

--- a/fn.go
+++ b/fn.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/crossplane-contrib/function-kcl/input/v1beta1"
 	pkgresource "github.com/crossplane-contrib/function-kcl/pkg/resource"
-	
 	"sigs.k8s.io/yaml"
 )
 
@@ -38,20 +37,25 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		response.Fatal(rsp, errors.Wrapf(err, "cannot get Function input from %T", req))
 		return rsp, nil
 	}
+	// Set default target
+	if in.Spec.Target == "" {
+		in.Spec.Target = pkgresource.Default
+	}
+	// Set default params
+	if in.Spec.Params == nil {
+		in.Spec.Params = make(map[string]runtime.RawExtension)
+	}
 	if err := in.Validate(); err != nil {
 		response.Fatal(rsp, errors.Wrap(err, "invalid function input"))
 		return rsp, nil
 	}
-
 	// The composite resource that actually exists.
 	oxr, err := request.GetObservedCompositeResource(req)
 	if err != nil {
 		response.Fatal(rsp, errors.Wrap(err, "cannot get observed composite resource"))
 		return rsp, nil
 	}
-	if in.Spec.Params == nil {
-		in.Spec.Params = make(map[string]runtime.RawExtension)
-	}
+	// Set option("params").oxr
 	in.Spec.Params["oxr"], err = pkgresource.UnstructuredToRawExtension(&oxr.Resource.Unstructured)
 	if err != nil {
 		response.Fatal(rsp, err)
@@ -70,6 +74,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		response.Fatal(rsp, errors.Wrap(err, "cannot get desired composite resource"))
 		return rsp, nil
 	}
+	// Set option("params").oxr
 	dxr.Resource.SetAPIVersion(oxr.Resource.GetAPIVersion())
 	dxr.Resource.SetKind(oxr.Resource.GetKind())
 	in.Spec.Params["dxr"], err = pkgresource.UnstructuredToRawExtension(&dxr.Resource.Unstructured)
@@ -77,7 +82,6 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		response.Fatal(rsp, err)
 		return rsp, nil
 	}
-
 	// The composed resources desired by any previous Functions in the pipeline.
 	desired, err := request.GetDesiredComposedResources(req)
 	if err != nil {
@@ -103,7 +107,6 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		response.Fatal(rsp, err)
 		return rsp, nil
 	}
-
 	// Input Example: https://github.com/kcl-lang/krm-kcl/blob/main/examples/mutation/set-annotations/suite/good.yaml
 	inputBytes, outputBytes := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
 	kclRunBytes, err := yaml.Marshal(in)
@@ -148,6 +151,13 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		response.Fatal(rsp, errors.Wrapf(err, "cannot process xr and state with the pipeline output in %T", rsp))
 		return rsp, nil
 	}
+	log.Debug(fmt.Sprintf("Set %d resource(s) to the desired state", result.MsgCount))
+	for _, msg := range result.Msgs {
+		rsp.Results = append(rsp.Results, &fnv1beta1.Result{
+			Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
+			Message:  msg,
+		})
+	}
 
 	// Set dxr and desired state
 	log.Debug(fmt.Sprintf("Setting desired XR state to %+v", dxr.Resource))
@@ -162,16 +172,6 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		response.Fatal(rsp, errors.Wrapf(err, "cannot set desired composed resources in %T", rsp))
 		return rsp, nil
 	}
-
-	log.Debug(fmt.Sprintf("Set %d resource(s) to the desired state", result.MsgCount))
-	for _, msg := range result.Msgs {
-		rsp.Results = append(rsp.Results, &fnv1beta1.Result{
-			Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-			Message:  msg,
-		})
-	}
-
 	log.Info("Successfully processed crossplane KCL function resources", "input", in.Name)
-
 	return rsp, nil
 }

--- a/fn.go
+++ b/fn.go
@@ -152,13 +152,6 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		return rsp, nil
 	}
 	log.Debug(fmt.Sprintf("Set %d resource(s) to the desired state", result.MsgCount))
-	for _, msg := range result.Msgs {
-		rsp.Results = append(rsp.Results, &fnv1beta1.Result{
-			Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-			Message:  msg,
-		})
-	}
-
 	// Set dxr and desired state
 	log.Debug(fmt.Sprintf("Setting desired XR state to %+v", dxr.Resource))
 	if err := response.SetDesiredCompositeResource(rsp, dxr); err != nil {

--- a/fn_test.go
+++ b/fn_test.go
@@ -58,12 +58,6 @@ func TestRunFunction(t *testing.T) {
 			want: want{
 				rsp: &fnv1beta1.RunFunctionResponse{
 					Meta: &fnv1beta1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{
-						{
-							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  "created resource \":Generated\"",
-						},
-					},
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -27,14 +27,14 @@ type KCLInput struct {
 	Spec RunSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
 }
 
-func (in KCLInput) Validate() error {
+func (in *KCLInput) Validate() error {
 	if in.Spec.Source == "" {
 		return field.Required(field.NewPath("spec.source"), "kcl source cannot be empty")
 	}
 
 	switch in.Spec.Target {
 	// Allowed targets
-	case resource.PatchDesired, resource.Resources, resource.XR:
+	case resource.Default, resource.PatchDesired, resource.Resources, resource.XR:
 	case resource.PatchResources:
 		if len(in.Spec.Resources) == 0 {
 			return field.Required(field.NewPath("spec.Resources"), fmt.Sprintf("%s target requires at least one resource", resource.PatchResources))
@@ -49,7 +49,7 @@ func (in KCLInput) Validate() error {
 			}
 		}
 	default:
-		return field.Required(field.NewPath("spec.target"), fmt.Sprintf("invalid target: %s", in.Spec.Target))
+		in.Spec.Target = resource.Default
 	}
 
 	return nil

--- a/pkg/resource/res.go
+++ b/pkg/resource/res.go
@@ -40,7 +40,6 @@ const (
 
 const (
 	AnnotationKeyReady = "krm.kcl.dev/ready"
-
 	MetaApiVersion = "meta.krm.kcl.dev/v1alpha1"
 )
 

--- a/pkg/resource/res.go
+++ b/pkg/resource/res.go
@@ -465,7 +465,11 @@ func ProcessResources(dxr *resource.Composite, oxr *resource.Composite, desired 
 				meta.RemoveAnnotations(cd.Resource, AnnotationKeyReady)
 			}
 			// Patch desired with resource meta name.
-			desired[resource.Name(cd.Resource.GetName())] = cd
+			AddResourcesTo(desired, &AddResourcesOptions{
+				Basename:  opts.Basename,
+				Data:      []unstructured.Unstructured{obj},
+				Overwrite: opts.Overwrite,
+			})
 		}
 		result.Object = data
 		result.MsgCount = len(data)

--- a/pkg/resource/res.go
+++ b/pkg/resource/res.go
@@ -40,7 +40,7 @@ const (
 
 const (
 	AnnotationKeyReady = "krm.kcl.dev/ready"
-	MetaApiVersion = "meta.krm.kcl.dev/v1alpha1"
+	MetaApiVersion     = "meta.krm.kcl.dev/v1alpha1"
 )
 
 type ResourceList []Resource
@@ -464,11 +464,7 @@ func ProcessResources(dxr *resource.Composite, oxr *resource.Composite, desired 
 				meta.RemoveAnnotations(cd.Resource, AnnotationKeyReady)
 			}
 			// Patch desired with resource meta name.
-			AddResourcesTo(desired, &AddResourcesOptions{
-				Basename:  opts.Basename,
-				Data:      []unstructured.Unstructured{obj},
-				Overwrite: opts.Overwrite,
-			})
+			desired[resource.Name(cd.Resource.GetName())] = cd
 		}
 		result.Object = data
 		result.MsgCount = len(data)


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

re #60 
re #59 

* Add `Default` target to generate xr and resources in the desired composite map.
* Support set connection details using the `CompositeConnectionDetails` resource.
* Bump the `function-kcl` version to v0.4.0

examples: examples/default/resources/README.md

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
