### PR TITLE
Ability to set custom composition resource name

### DIFF
--- a/examples/resources/custom_composition_resource_name/Makefile
+++ b/examples/resources/custom_composition_resource_name/Makefile
@@ -1,0 +1,2 @@
+run:
+	crossplane beta render xr.yaml composition.yaml functions.yaml -r

--- a/examples/resources/custom_composition_resource_name/README.md
+++ b/examples/resources/custom_composition_resource_name/README.md
@@ -1,0 +1,48 @@
+# Example Manifests
+
+You can run your function locally and test it using `crossplane beta render`
+with these example manifests.
+
+```shell
+# Run the function locally
+$ go run . --insecure --debug
+```
+
+```shell
+# Then, in another terminal, call it with these example manifests
+$ crossplane beta render xr.yaml composition.yaml functions.yaml -r
+---
+apiVersion: example.crossplane.io/v1
+kind: XR
+metadata:
+  name: example-xr
+status:
+  conditions:
+  - lastTransitionTime: "2024-01-01T00:00:00Z"
+    message: 'Unready resources: custom-composition-resource-name'
+    reason: Creating
+    status: "False"
+    type: Ready
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: custom-composition-resource-name
+  generateName: example-xr-
+  labels:
+    crossplane.io/composite: example-xr
+  name: instance
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example-xr
+    uid: ""
+spec:
+  forProvider:
+    ami: ami-0d9858aa3c6322f73
+    instanceType: t2.micro
+    region: us-east-2
+```

--- a/examples/resources/custom_composition_resource_name/composition.yaml
+++ b/examples/resources/custom_composition_resource_name/composition.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-template-go
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: normal
+    functionRef:
+      name: kcl-function
+    input:
+      apiVersion: krm.kcl.dev/v1alpha1
+      kind: KCLRun
+      metadata:
+        name: basic
+      spec:
+        source: |
+          {
+              apiVersion: "ec2.aws.upbound.io/v1beta1"
+              kind: "Instance"
+              metadata.name = "instance"
+              metadata.annotations = {
+                "krm.kcl.dev/composition-resource-name" = "custom-composition-resource-name"
+              }
+              spec.forProvider.ami: "ami-0d9858aa3c6322f73"
+              spec.forProvider.instanceType: "t2.micro"
+              spec.forProvider.region: "us-east-2"
+          }

--- a/examples/resources/custom_composition_resource_name/functions.yaml
+++ b/examples/resources/custom_composition_resource_name/functions.yaml
@@ -1,0 +1,9 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: kcl-function
+  annotations:
+    # This tells crossplane beta render to connect to the function locally.
+    render.crossplane.io/runtime: Development
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:latest

--- a/examples/resources/custom_composition_resource_name/xr.yaml
+++ b/examples/resources/custom_composition_resource_name/xr.yaml
@@ -1,0 +1,6 @@
+# Replace this with your XR!
+apiVersion: example.crossplane.io/v1
+kind: XR
+metadata:
+  name: example-xr
+spec: {}

--- a/examples/resources/custom_external_name/Makefile
+++ b/examples/resources/custom_external_name/Makefile
@@ -1,0 +1,2 @@
+run:
+	crossplane beta render xr.yaml composition.yaml functions.yaml -r

--- a/examples/resources/custom_external_name/README.md
+++ b/examples/resources/custom_external_name/README.md
@@ -1,0 +1,49 @@
+# Example Manifests
+
+You can run your function locally and test it using `crossplane beta render`
+with these example manifests.
+
+```shell
+# Run the function locally
+$ go run . --insecure --debug
+```
+
+```shell
+# Then, in another terminal, call it with these example manifests
+$ crossplane beta render xr.yaml composition.yaml functions.yaml -r
+---
+apiVersion: example.crossplane.io/v1
+kind: XR
+metadata:
+  name: example-xr
+status:
+  conditions:
+  - lastTransitionTime: "2024-01-01T00:00:00Z"
+    message: 'Unready resources: instance'
+    reason: Creating
+    status: "False"
+    type: Ready
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: instance
+    crossplane.io/external-name: custom-external-name
+  generateName: example-xr-
+  labels:
+    crossplane.io/composite: example-xr
+  name: instance
+  ownerReferences:
+  - apiVersion: example.crossplane.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XR
+    name: example-xr
+    uid: ""
+spec:
+  forProvider:
+    ami: ami-0d9858aa3c6322f73
+    instanceType: t2.micro
+    region: us-east-2
+```

--- a/examples/resources/custom_external_name/composition.yaml
+++ b/examples/resources/custom_external_name/composition.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-template-go
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: normal
+    functionRef:
+      name: kcl-function
+    input:
+      apiVersion: krm.kcl.dev/v1alpha1
+      kind: KCLRun
+      metadata:
+        name: basic
+      spec:
+        source: |
+          {
+              apiVersion: "ec2.aws.upbound.io/v1beta1"
+              kind: "Instance"
+              metadata.name = "instance"
+              metadata.annotations = {
+                "crossplane.io/external-name" = "custom-external-name"
+              }
+              spec.forProvider.ami: "ami-0d9858aa3c6322f73"
+              spec.forProvider.instanceType: "t2.micro"
+              spec.forProvider.region: "us-east-2"
+          }

--- a/examples/resources/custom_external_name/functions.yaml
+++ b/examples/resources/custom_external_name/functions.yaml
@@ -1,0 +1,9 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: kcl-function
+  annotations:
+    # This tells crossplane beta render to connect to the function locally.
+    render.crossplane.io/runtime: Development
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:latest

--- a/examples/resources/custom_external_name/xr.yaml
+++ b/examples/resources/custom_external_name/xr.yaml
@@ -1,0 +1,6 @@
+# Replace this with your XR!
+apiVersion: example.crossplane.io/v1
+kind: XR
+metadata:
+  name: example-xr
+spec: {}

--- a/fn_test.go
+++ b/fn_test.go
@@ -109,6 +109,45 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
+		"CustomCompositionResourceNameIsSet": {
+			reason: "The Function should set value of crossplane.io/composition-resource-name annotation by krm.kcl.dev/composition-resource-name annotation ",
+			args: args{
+				req: &fnv1beta1.RunFunctionRequest{
+					Meta: &fnv1beta1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "krm.kcl.dev/v1alpha1",
+						"kind": "KCLRun",
+						"metadata": {
+							"name": "basic"
+						},
+						"spec": {
+							"target": "Default",
+							"source": "{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata.annotations = {\"krm.kcl.dev/composition-resource-name\": \"custom-composition-resource-name\"}\n}"
+						}
+					}`),
+					Observed: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1beta1.RunFunctionResponse{
+					Meta: &fnv1beta1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Desired: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+						Resources: map[string]*fnv1beta1.Resource{
+							"custom-composition-resource-name": {
+								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated","metadata":{"annotations":{}}}`),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/pkg/resource/res.go
+++ b/pkg/resource/res.go
@@ -39,8 +39,9 @@ const (
 )
 
 const (
-	AnnotationKeyReady = "krm.kcl.dev/ready"
-	MetaApiVersion     = "meta.krm.kcl.dev/v1alpha1"
+	AnnotationKeyReady                   = "krm.kcl.dev/ready"
+	AnnotationKeyCompositionResourceName = "krm.kcl.dev/composition-resource-name"
+	MetaApiVersion                       = "meta.krm.kcl.dev/v1alpha1"
 )
 
 type ResourceList []Resource
@@ -471,8 +472,13 @@ func ProcessResources(dxr *resource.Composite, oxr *resource.Composite, desired 
 				// Remove meta annotation.
 				meta.RemoveAnnotations(cd.Resource, AnnotationKeyReady)
 			}
-			// Patch desired with resource meta name.
-			desired[resource.Name(cd.Resource.GetName())] = cd
+			// Patch desired with custom name from annotation or default to resource meta name.
+			name, found := cd.Resource.GetAnnotations()[AnnotationKeyCompositionResourceName]
+			if !found {
+				name = cd.Resource.GetName()
+			}
+			meta.RemoveAnnotations(cd.Resource, AnnotationKeyCompositionResourceName)
+			desired[resource.Name(name)] = cd
 		}
 		result.Object = data
 		result.MsgCount = len(data)


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* `krm.kcl.dev/composition-resource-name` annotation to override composition resource name in the desired composed resource map
* The custom name will be eventually propagated to `crossplane.io/composition-resource-name`
* `krm.kcl.dev/composition-resource-name` annotation is automatically removed from the composed resource similar to any other special function annotations
* Extend function test suite
* Add associated example of `examples/resources/custom_composition_resource_name`
* Add related example of `examples/resources/custom_external_name` to demonstrace external-name override
* Fixes #77

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
