### PR TITLE
Add note on fetching cluster-scoped vs namespaced resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,9 @@ spec:
 ### Extra resources
 By defining one or more special `ExtraResources`, you can ask Crossplane to retrieve additional resources from the local cluster and make them available to your templates. See the [docs](https://github.com/crossplane/crossplane/blob/main/design/design-doc-composition-functions-extra-resources.md) for more information.
 
+> With ExtraResources, you can fetch cluster-scoped resources, but not namespaced resources such as claims.
+> If you need to get a composite resource via its claim name you can use `matchLabels` with `crossplane.io/claim-name: <claimname>`
+
 ```yaml
 apiVersion: krm.kcl.dev/v1alpha1
 kind: KCLInput


### PR DESCRIPTION
### Description of your changes

As extra resources does only support fetching cluster scoped resources this PR improves the docs to clarify this

Fixes #172 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
