### PR TITLE
fix(resource): also ignore no such element err

### DIFF
--- a/pkg/resource/res.go
+++ b/pkg/resource/res.go
@@ -292,10 +292,6 @@ func AddResourcesTo(o any, opts *AddResourcesOptions) error {
 	return nil
 }
 
-var (
-	errNoSuchField = "no such field"
-)
-
 // SetData is a recursive function that is intended to build a kube fieldpath valid
 // JSONPath(s) of the given object, it will then copy from 'data' at the given path
 // to the passed o object - at the same path, overwrite defines if this function should
@@ -351,7 +347,7 @@ func SetData(data any, path string, o any, overwrite bool) error {
 				return errors.New("cannot set data on a nil DesiredComposed resource")
 			}
 
-			if curVal, err := r.GetValue(path); err != nil && !strings.Contains(err.Error(), errNoSuchField) {
+			if curVal, err := r.GetValue(path); err != nil && !fieldpath.IsNotFound(err) {
 				return errors.Wrapf(err, "getting %s:%s in xr failed", path, data)
 			} else if curVal != nil && !overwrite {
 				return fmt.Errorf("%s: conflicting values %q and %q", path, curVal, data)
@@ -371,7 +367,7 @@ func SetData(data any, path string, o any, overwrite bool) error {
 				return fmt.Errorf("cannot set data on a nil XR")
 			}
 
-			if curVal, err := r.GetValue(path); err != nil && !strings.Contains(err.Error(), errNoSuchField) {
+			if curVal, err := r.GetValue(path); err != nil && !fieldpath.IsNotFound(err) {
 				return errors.Wrapf(err, "getting %s:%s in xr failed", path, data)
 			} else if curVal != nil && !overwrite {
 				return fmt.Errorf("%s: conflicting values %q and %q", path, curVal, data)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Since `crossplane-runtime` might also return a "no such element" error, we must also interpret that case, and ignore it in order to patch the existing array with a new element.

https://github.com/crossplane/crossplane-runtime/blob/19d95a69cc03690c4b867ff91d89681fcf872a93/pkg/fieldpath/paved.go#L124-L126

Previous to this change, we only dealt with the "no such field" error:

https://github.com/crossplane/crossplane-runtime/blob/19d95a69cc03690c4b867ff91d89681fcf872a93/pkg/fieldpath/paved.go#L135-L137

In this case, the lib provides an exported method to check for not found without the need for us to compare against the error's string. This way we also nicely decouple our logic from implementation details on `crossplane-runtime`.

Fixes #193 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
