### PR TITLE
Allow a default source to be configured via environment variable

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -20,6 +21,8 @@ import (
 	pkgresource "github.com/crossplane-contrib/function-kcl/pkg/resource"
 	"sigs.k8s.io/yaml"
 )
+
+var defaultSource = os.Getenv("FUNCTION_KCL_DEFAULT_SOURCE")
 
 // Function returns whatever response you ask it to.
 type Function struct {
@@ -38,6 +41,10 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	if err := request.GetInput(req, in); err != nil {
 		response.Fatal(rsp, errors.Wrapf(err, "cannot get Function input from %T", req))
 		return rsp, nil
+	}
+	// Set default source
+	if in.Spec.Source == "" {
+		in.Spec.Source = defaultSource
 	}
 	// Set default target
 	if in.Spec.Target == "" {


### PR DESCRIPTION
### Description of your changes

Enable function-kcl to be used as a base image for custom functions built in KCL by allowing the function input to be empty when a default source is set via environment variable. A user can build a custom function on top of function-kcl by including a directory containing a KCL module and setting the environment variable `FUNCTION_KCL_DEFAULT_SOURCE` to the module's path.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.
