### PR TITLE
Return error for duplicate names in composed resources

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ env:
   XPKG: xpkg.upbound.io/${{ github.repository}}
 
   # The package version to push. The default is 0.0.0-gitsha.
-  XPKG_VERSION: v0.11.2
+  XPKG_VERSION: v0.11.3
 
 jobs:
   lint:

--- a/fn_test.go
+++ b/fn_test.go
@@ -652,11 +652,11 @@ func TestRunFunctionSimple(t *testing.T) {
 				},
 			},
 		},
-		"MultipleResourceError": {
-			reason: "The Function should return a fatal result if input resources have duplicate names",
+		"DuplicateNameError": {
+			reason: "The Function should return a fatal result if composed resources have duplicate name",
 			args: args{
 				req: &fnv1.RunFunctionRequest{
-					Meta: &fnv1.RequestMeta{Tag: "multiple-resource-error"},
+					Meta: &fnv1.RequestMeta{Tag: "duplicate-name-error"},
 					Input: resource.MustStructJSON(`{
 						"apiVersion": "krm.kcl.dev/v1alpha1",
 						"kind": "KCLInput",
@@ -664,7 +664,7 @@ func TestRunFunctionSimple(t *testing.T) {
 							"name": "basic"
 						},
 						"spec": {
-							"source": "items = [\n{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata.annotations = {\"krm.kcl.dev/composition-resource-name\": \"custom-composition-resource-name\"}\n}\n{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata.annotations = {\"krm.kcl.dev/composition-resource-name\": \"custom-composition-resource-name\"}\n}\n]\n"
+							"source": "items = [\n{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata = {\n  name = \"metadata-name\"\n  annotations = {\"krm.kcl.dev/composition-resource-name\": \"duplicate-resource-name\"}}\n}\n{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata.name = \"duplicate-resource-name\"\n}\n]\n"
 						}
 					}`),
 					Observed: &fnv1.State{
@@ -676,14 +676,53 @@ func TestRunFunctionSimple(t *testing.T) {
 			},
 			want: want{
 				rsp: &fnv1.RunFunctionResponse{
-					Meta: &fnv1.ResponseMeta{Tag: "multiple-resource-error", Ttl: durationpb.New(response.DefaultTTL)},
+					Meta: &fnv1.ResponseMeta{Tag: "duplicate-name-error", Ttl: durationpb.New(response.DefaultTTL)},
 					Results: []*fnv1.Result{
 						{
 							Severity: fnv1.Severity_SEVERITY_FATAL,
 							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
-							Message:  "cannot process xr and state with the pipeline output in *v1.RunFunctionResponse: duplicate resource names custom-composition-resource-name found, when returning multiple resources, you need to set different metadata.name or metadata.annotations.\"krm.kcl.dev/composition-resource-name\" to distinguish between different resources in the composition functions.",
+							Message:  "cannot process xr and state with the pipeline output in *v1.RunFunctionResponse: multiple composed resources with name \"duplicate-resource-name\" returned: Generated/metadata-name and Generated/duplicate-resource-name. Set different metadata.name or metadata.annotations.\"krm.kcl.dev/composition-resource-name\" to distinguish them.",
 						},
 					}},
+			},
+		},
+		"ComposedSameNameAsXR": {
+			reason: "The Function should succeed even when a composed resource has the same name as a patched composite",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "krm.kcl.dev/v1alpha1",
+						"kind": "KCLInput",
+						"metadata": {
+							"name": "basic"
+						},
+						"spec": {
+							"target": "Default",
+							"source": "[{\n    apiVersion: \"example.org/v1\"\n    kind: \"XR\"\n metadata.name = \"cool-xr\"\n},{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata.name = \"cool-xr\"\n}]"
+						}
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","status":{}}`),
+						},
+						Resources: map[string]*fnv1.Resource{
+							"cool-xr": {
+								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated","metadata":{"name":"cool-xr"}}`),
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/fn_test.go
+++ b/fn_test.go
@@ -652,40 +652,40 @@ func TestRunFunctionSimple(t *testing.T) {
 				},
 			},
 		},
-		// TODO: disable the resource check, and fix the kcl dup resource evaluation issues.
-		// "MultipleResourceError": {
-		// 	reason: "The Function should return a fatal result if input resources have duplicate names",
-		// 	args: args{
-		// 		req: &fnv1.RunFunctionRequest{
-		// 			Meta: &fnv1.RequestMeta{Tag: "multiple-resource-error"},
-		// 			Input: resource.MustStructJSON(`{
-		// 				"apiVersion": "krm.kcl.dev/v1alpha1",
-		// 				"kind": "KCLInput",
-		// 				"metadata": {
-		// 					"name": "basic"
-		// 				},
-		// 				"spec": {
-		// 					"source": "items = [\n{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata.annotations = {\"krm.kcl.dev/composition-resource-name\": \"custom-composition-resource-name\"}\n}\n{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata.annotations = {\"krm.kcl.dev/composition-resource-name\": \"custom-composition-resource-name\"}\n}\n]\n"
-		// 				}
-		// 			}`),
-		// 			Observed: &fnv1.State{
-		// 				Composite: &fnv1.Resource{
-		// 					Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	want: want{
-		// 		rsp: &fnv1.RunFunctionResponse{
-		// 			Meta: &fnv1.ResponseMeta{Tag: "multiple-resource-error", Ttl: durationpb.New(response.DefaultTTL)},
-		// 			Results: []*fnv1.Result{
-		// 				{
-		// 					Severity: fnv1.Severity_SEVERITY_FATAL,
-		// 					Message:  "cannot process xr and state with the pipeline output in *v1beta1.RunFunctionResponse: duplicate resource names custom-composition-resource-name found, when returning multiple resources, you need to set different metadata.name or metadata.annotations.\"krm.kcl.dev/composition-resource-name\" to distinguish between different resources in the composition functions.",
-		// 				},
-		// 			}},
-		// 	},
-		// },
+		"MultipleResourceError": {
+			reason: "The Function should return a fatal result if input resources have duplicate names",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "multiple-resource-error"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "krm.kcl.dev/v1alpha1",
+						"kind": "KCLInput",
+						"metadata": {
+							"name": "basic"
+						},
+						"spec": {
+							"source": "items = [\n{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata.annotations = {\"krm.kcl.dev/composition-resource-name\": \"custom-composition-resource-name\"}\n}\n{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n metadata.annotations = {\"krm.kcl.dev/composition-resource-name\": \"custom-composition-resource-name\"}\n}\n]\n"
+						}
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "multiple-resource-error", Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{
+						{
+							Severity: fnv1.Severity_SEVERITY_FATAL,
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+							Message:  "cannot process xr and state with the pipeline output in *v1.RunFunctionResponse: duplicate resource names custom-composition-resource-name found, when returning multiple resources, you need to set different metadata.name or metadata.annotations.\"krm.kcl.dev/composition-resource-name\" to distinguish between different resources in the composition functions.",
+						},
+					}},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/pkg/resource/res.go
+++ b/pkg/resource/res.go
@@ -523,8 +523,7 @@ func CheckAndSetDesired(desired map[resource.Name]*resource.DesiredComposed, che
 	if _, existed := checked[name]; existed {
 		return errors.Errorf("duplicate resource names %s found, when returning multiple resources, you need to set different metadata.name or metadata.annotations.\"krm.kcl.dev/composition-resource-name\" to distinguish between different resources in the composition functions.", name)
 	}
-	// TODO: disable the resource check, and fix the kcl dup resource evaluation issues.
-	// checked[name] = struct{}{}
+	checked[name] = struct{}{}
 	desired[resource.Name(name)] = cd
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Returns an error when multiple composed resources returned by a Default or Resources target have the same composition resource name. Previously, all but one of such composed resources would be silently discarded.

Fixes #241 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
