### PR TITLE
feat: add flag to add dependencies to all functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,32 @@ ENV FUNCTION_KCL_DEFAULT_SOURCE=/src/main.k
 
 You may also wish to replace the `/package.yaml` metadata file to give your new function a unique name and remove or replace the input CRD.
 
+#### Including modules in the base image
+
+You may include KCL modules in a custom base image. First, copy the module directories into the image:
+
+```dockerfile
+ADD kcl /kcl
+```
+
+Next, add a file specifying the dependencies to be added to all functions, using
+the syntax of the `[dependencies]` section of `kcl.mod`, for example:
+
+```dockerfile
+ADD dependencies /dependecies
+```
+where the file `dependencies` contains:
+
+```kcl
+example = { path = "/kcl/example" }
+```
+
+Finally, specify the location of the `dependencies` file in the ENTRYPOINT:
+
+```dockerfile
+CMD ["--dependencies", "/dependencies"]
+```
+
 ### Read the Function Requests and Values through the `option` Function
 
 + Read the [`ObservedCompositeResource`](https://docs.crossplane.io/latest/concepts/composition-functions/#observed-state) from `option("params").oxr`.

--- a/fn.go
+++ b/fn.go
@@ -29,7 +29,8 @@ var defaultSource = os.Getenv("FUNCTION_KCL_DEFAULT_SOURCE")
 type Function struct {
 	fnv1.UnimplementedFunctionRunnerServiceServer
 
-	log logging.Logger
+	log          logging.Logger
+	dependencies string
 }
 
 // RunFunction runs the Function.
@@ -54,6 +55,10 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	// Set default params
 	if in.Spec.Params == nil {
 		in.Spec.Params = make(map[string]runtime.RawExtension)
+	}
+	// Add base dependencies
+	if f.dependencies != "" {
+		in.Spec.Dependencies = f.dependencies + "\n" + in.Spec.Dependencies
 	}
 	if err := in.Validate(); err != nil {
 		response.Fatal(rsp, errors.Wrap(err, "invalid function input"))

--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/alecthomas/kong"
 
 	"github.com/crossplane/function-sdk-go"
@@ -11,19 +14,28 @@ import (
 type CLI struct {
 	Debug bool `short:"d" help:"Emit debug logs in addition to info logs."`
 
-	Network     string `help:"Network on which to listen for gRPC connections." default:"tcp"`
-	Address     string `help:"Address at which to listen for gRPC connections." default:":9443"`
-	TLSCertsDir string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
-	Insecure    bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	Network      string `help:"Network on which to listen for gRPC connections." default:"tcp"`
+	Address      string `help:"Address at which to listen for gRPC connections." default:":9443"`
+	TLSCertsDir  string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
+	Dependencies string `help:"File containing dependencies to add to all functions."`
+	Insecure     bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
 }
 
 // Run this Function.
 func (c *CLI) Run() error {
+	dependencies := ""
+	if c.Dependencies != "" {
+		if bytes, err := os.ReadFile(c.Dependencies); err != nil {
+			return fmt.Errorf("reading %q: %w", c.Dependencies, err)
+		} else {
+			dependencies = string(bytes)
+		}
+	}
 	log, err := function.NewLogger(c.Debug)
 	if err != nil {
 		return err
 	}
-	return function.Serve(&Function{log: log},
+	return function.Serve(&Function{dependencies: dependencies, log: log},
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
 		function.Insecure(c.Insecure))


### PR DESCRIPTION

### Description of your changes

Adds the ability for a custom image to provide dependencies that are available to all functions run through that image.
This allows the custom image to embed KCL modules that are then easy to consume.

Fixes #257

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

There doesn't appear to be much here that is testable.
