### PR TITLE
feat: pass credential secrets from pipeline

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -60,6 +60,23 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	if f.dependencies != "" {
 		in.Spec.Dependencies = f.dependencies + "\n" + in.Spec.Dependencies
 	}
+	// Add credentials
+	if creds, ok := req.Credentials["kcl-registry"]; ok {
+		data := creds.GetCredentialData()
+		if data != nil {
+			if password, ok := data.Data["password"]; ok {
+				in.Spec.Credentials.Password = string(password)
+				if username, ok := data.Data["username"]; ok {
+					in.Spec.Credentials.Username = string(username)
+				}
+				if url, ok := data.Data["url"]; ok {
+					in.Spec.Credentials.Url = string(url)
+				}
+			} else {
+				log.Info("Warning: required password not found in the credentials")
+			}
+		}
+	}
 	if err := in.Validate(); err != nil {
 		response.Fatal(rsp, errors.Wrap(err, "invalid function input"))
 		return rsp, nil


### PR DESCRIPTION
Support reading KCL registry credentials from Kubernetes Secret. Secret can be specified in the composition's pipeline step credentials and used in `crossplane render --function-credentials`.

### Description of your changes

This adds support for [pipeline step credentials](https://docs.crossplane.io/latest/api/#Composition-spec-pipeline-credentials) for KCL registry credentials. This allows pulling KCL source code from private repositories by providing credentials in a Kubernetes Secret.

Fixes #272 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
