### PR TITLE
Fix krm.kcl.dev/ready annotation for all targets

### DIFF
--- a/pkg/resource/res.go
+++ b/pkg/resource/res.go
@@ -408,6 +408,17 @@ func ProcessResources(dxr *resource.Composite, oxr *resource.Composite, desired 
 		if err := AddResourcesTo(desiredMatches, opts); err != nil {
 			return result, err
 		}
+		// Process ready annotations
+		for _, cd := range desired {
+			if v, found := cd.Resource.GetAnnotations()[AnnotationKeyReady]; found {
+				if v != string(resource.ReadyTrue) && v != string(resource.ReadyUnspecified) && v != string(resource.ReadyFalse) {
+					return result, errors.Errorf("invalid function input: invalid %q annotation value %q: must be True, False, or Unspecified", AnnotationKeyReady, v)
+				}
+				cd.Ready = resource.Ready(v)
+				// Remove meta annotation.
+				meta.RemoveAnnotations(cd.Resource, AnnotationKeyReady)
+			}
+		}
 		result.Object = data
 		result.MsgCount = len(data)
 	case PatchResources:
@@ -425,11 +436,33 @@ func ProcessResources(dxr *resource.Composite, oxr *resource.Composite, desired 
 		if err := AddResourcesTo(desiredMatches, opts); err != nil {
 			return result, err
 		}
+		// Process ready annotations
+		for _, cd := range desired {
+			if v, found := cd.Resource.GetAnnotations()[AnnotationKeyReady]; found {
+				if v != string(resource.ReadyTrue) && v != string(resource.ReadyUnspecified) && v != string(resource.ReadyFalse) {
+					return result, errors.Errorf("invalid function input: invalid %q annotation value %q: must be True, False, or Unspecified", AnnotationKeyReady, v)
+				}
+				cd.Ready = resource.Ready(v)
+				// Remove meta annotation.
+				meta.RemoveAnnotations(cd.Resource, AnnotationKeyReady)
+			}
+		}
 		result.Object = data
 		result.MsgCount = len(data)
 	case Resources:
 		if err := AddResourcesTo(desired, opts); err != nil {
 			return result, err
+		}
+		// Process ready annotations
+		for _, cd := range desired {
+			if v, found := cd.Resource.GetAnnotations()[AnnotationKeyReady]; found {
+				if v != string(resource.ReadyTrue) && v != string(resource.ReadyUnspecified) && v != string(resource.ReadyFalse) {
+					return result, errors.Errorf("invalid function input: invalid %q annotation value %q: must be True, False, or Unspecified", AnnotationKeyReady, v)
+				}
+				cd.Ready = resource.Ready(v)
+				// Remove meta annotation.
+				meta.RemoveAnnotations(cd.Resource, AnnotationKeyReady)
+			}
 		}
 		// Pass data here instead of desired
 		// This is because there already may be desired objects


### PR DESCRIPTION
**Fixes #314**

## Problem

The `krm.kcl.dev/ready` annotation only worked with `target: "Default"`. When using `target: "Resources"`, `target: "PatchDesired"`, or `target: "PatchResources"`, resources with ready annotations were never marked as ready.

## Example

This KCL code:
```kcl
{
    apiVersion = "postgresql.cnpg.io/v1"
    kind = "ScheduledBackup"
    metadata = {
        annotations = {
            "krm.kcl.dev/ready": "True"  # <- Was ignored
        }
    }
}
```

With `target: "Resources"` would create the resource but never mark it ready, causing stalled compositions.

## Root Cause

The annotation processing code was only in the `case Default:` block. Other target types skipped annotation processing entirely.

## Fix

Added ready annotation processing to all target types:
- `PatchDesired`
- `PatchResources`  
- `Resources`

The processing happens after `AddResourcesTo()` to preserve the `Ready` field.

## Result

Now `krm.kcl.dev/ready: "True"` works with any target type, not just `Default`.

## Testing

- All existing tests pass
- Tested with real Crossplane deployment using `target: "Resources"`
- Resources now properly marked as ready