### PR TITLE
perf: skip the YAML round trip when rendering inline KCL

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -205,31 +205,51 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	// Input Example: https://github.com/kcl-lang/krm-kcl/blob/main/examples/mutation/set-annotations/suite/good.yaml
 	in.APIVersion = v1alpha1.KCLRunAPIVersion
 	in.Kind = api.KCLRunKind
-	// Note use "sigs.k8s.io/yaml" here.
-	kclRunBytes, err := yaml.Marshal(in)
-	if err != nil {
-		response.Fatal(rsp, errors.Wrap(err, "cannot marshal input to yaml"))
-		return rsp, nil
+	// The KCL render is deterministic over the input (source + dependencies +
+	// all params + config), so renderKey identifies it. Reuse the previous output
+	// for byte-identical inputs to skip recompiling the module — this avoids both
+	// the CPU cost and a native memory-leak increment on no-op re-syncs. See
+	// rendercache.go.
+	var key []byte
+	if f.cache.enabled() {
+		if key, err = renderKey(in); err != nil {
+			response.Fatal(rsp, errors.Wrap(err, "cannot derive render cache key"))
+			return rsp, nil
+		}
 	}
-	// The KCL render is deterministic over kclRunBytes (source + dependencies +
-	// all params + config). Reuse the previous output for byte-identical inputs
-	// to skip recompiling the module — this avoids both the CPU cost and a native
-	// memory-leak increment on no-op re-syncs. See rendercache.go.
+
 	var outputData []byte
-	if cached, ok := f.cache.lookup(kclRunBytes); ok {
+	if cached, ok := f.cache.lookup(key); ok {
 		outputData = cached
 		hits, misses := f.cache.stats()
 		log.Debug("render cache hit", "hits", hits, "misses", misses)
 	} else {
-		inputBytes, outputBytes := bytes.NewBuffer(kclRunBytes), bytes.NewBuffer([]byte{})
-		// Run pipeline to get the result mutated or validated by the KCL source.
-		pipeline := kio.NewPipeline(inputBytes, outputBytes, false)
-		if err := pipeline.Execute(); err != nil {
+		// Fast path: feed the KCL runtime the JSON we already hold, skipping the
+		// JSON -> YAML -> RNode -> JSON round trip. Falls back to the krm-kcl
+		// pipeline for non-inline sources (oci://, git, http, local path).
+		out, ok, err := renderInline(in)
+		if err != nil {
 			response.Fatal(rsp, errors.Wrap(err, "failed to run kcl function pipelines"))
 			return rsp, nil
 		}
-		outputData = outputBytes.Bytes()
-		f.cache.store(kclRunBytes, outputData)
+		if !ok {
+			// Note use "sigs.k8s.io/yaml" here.
+			kclRunBytes, err := yaml.Marshal(in)
+			if err != nil {
+				response.Fatal(rsp, errors.Wrap(err, "cannot marshal input to yaml"))
+				return rsp, nil
+			}
+			inputBytes, outputBytes := bytes.NewBuffer(kclRunBytes), bytes.NewBuffer([]byte{})
+			// Run pipeline to get the result mutated or validated by the KCL source.
+			pipeline := kio.NewPipeline(inputBytes, outputBytes, false)
+			if err := pipeline.Execute(); err != nil {
+				response.Fatal(rsp, errors.Wrap(err, "failed to run kcl function pipelines"))
+				return rsp, nil
+			}
+			out = outputBytes.Bytes()
+		}
+		outputData = out
+		f.cache.store(key, outputData)
 	}
 	log.Debug(fmt.Sprintf("Pipeline output: %v", string(outputData)))
 	data, err := pkgresource.DataResourcesFromYaml(outputData)

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,12 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.35.4
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
+	kcl-lang.io/cli v0.12.4
+	kcl-lang.io/kpm v0.12.4
 	kcl-lang.io/krm-kcl v0.12.4
 	oras.land/oras-go/v2 v2.6.2
 	sigs.k8s.io/controller-tools v0.20.1
+	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -257,15 +260,12 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20251215205346-5ee0d033ba5b // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
-	kcl-lang.io/cli v0.12.4 // indirect
 	kcl-lang.io/kcl-go v0.12.3 // indirect
 	kcl-lang.io/kcl-openapi v0.10.2 // indirect
-	kcl-lang.io/kpm v0.12.4 // indirect
 	kcl-lang.io/lib v0.12.3 // indirect
 	oras.land/oras-go v1.2.6 // indirect
 	sigs.k8s.io/controller-runtime v0.23.3 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )

--- a/render.go
+++ b/render.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"kcl-lang.io/cli/pkg/options"
+	"kcl-lang.io/kpm/pkg/client"
+	"kcl-lang.io/krm-kcl/pkg/edit"
+	"kcl-lang.io/krm-kcl/pkg/source"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+
+	fkcl "github.com/crossplane-contrib/function-kcl/input/v1alpha1"
+)
+
+// The default render path serializes the whole KCLInput to YAML, hands it to the
+// krm-kcl byte-stream pipeline, which parses it back into kyaml RNodes, and then
+// re-serializes those RNodes to JSON to build the KCL top-level arguments:
+//
+//	JSON (RawExtension) -> YAML -> parse -> RNode -> JSON -> KCL
+//
+// We already hold JSON, and KCL wants JSON. Everything in between is conversion,
+// and for a composition whose observed state is large (a Kubernetes resource with
+// a fat status subresource) it dominates the cost of a RunFunction call, along
+// with the GC pressure from the allocation churn it creates.
+//
+// renderInline skips it: it assembles the KCL arguments straight from the bytes
+// we already have and invokes the KCL runtime directly. It handles the inline
+// `source` case, which is the common one for Crossplane compositions; anything
+// else (oci://, git, http, a local path) falls back to the krm-kcl pipeline.
+
+// renderInline runs the KCL program without the YAML round trip. ok is false when
+// the input is not something this path handles, in which case the caller must
+// fall back to the krm-kcl pipeline.
+func renderInline(in *fkcl.KCLInput) (out []byte, ok bool, err error) {
+	if !isInlineSource(in.Spec.Source) {
+		return nil, false, nil
+	}
+
+	// Resolve dependencies the same way krm-kcl's KCLRun.Transform does.
+	var dependencies []string
+	if in.Spec.Dependencies != "" {
+		cli, err := client.NewKpmClient()
+		if err != nil {
+			return nil, true, err
+		}
+		if dependencies, err = edit.LoadDepListFromConfig(cli, in.Spec.Dependencies); err != nil {
+			return nil, true, err
+		}
+	}
+
+	dir, err := os.MkdirTemp("", "kcl-sandbox")
+	if err != nil {
+		return nil, true, err
+	}
+	defer os.RemoveAll(dir)
+
+	prog := filepath.Join(dir, "prog.k")
+	if err := os.WriteFile(prog, []byte(in.Spec.Source), 0o600); err != nil {
+		return nil, true, err
+	}
+
+	args, err := kclArguments(in)
+	if err != nil {
+		return nil, true, err
+	}
+
+	buf := bytes.NewBuffer(nil)
+	opts := options.NewRunOptions()
+	opts.NoStyle = true
+	opts.Entries = []string{prog}
+	opts.Arguments = args
+	opts.Writer = buf
+	if len(dependencies) > 0 {
+		opts.ExternalPackages = dependencies
+	}
+	if c := &in.Spec.Config; c != nil {
+		opts.Debug = c.Debug
+		opts.DisableNone = c.DisableNone
+		opts.Overrides = c.Overrides
+		opts.PathSelectors = c.PathSelectors
+		opts.Settings = c.Settings
+		opts.ShowHidden = c.ShowHidden
+		opts.SortKeys = c.SortKeys
+		opts.StrictRangeCheck = c.StrictRangeCheck
+		opts.Vendor = c.Vendor
+		opts.Arguments = append(opts.Arguments, c.Arguments...)
+	}
+
+	if err := opts.Complete([]string{}); err != nil {
+		return nil, true, err
+	}
+	if err := opts.Validate(); err != nil {
+		return nil, true, err
+	}
+	if err := opts.Run(); err != nil {
+		return nil, true, err
+	}
+
+	// KCL emits every top-level variable; krm-kcl's contract is that the resources
+	// live under `items`. Unwrap exactly as SimpleTransformer.Transform does. This
+	// operates on the output, which is small — the saving is all on the input side.
+	nodes, err := (&kio.ByteReader{Reader: buf, OmitReaderAnnotations: true}).Read()
+	if err != nil {
+		return nil, true, err
+	}
+	items, _, err := edit.UnwrapResources(nodes)
+	if err != nil {
+		return nil, true, err
+	}
+
+	res := bytes.NewBuffer(nil)
+	if err := (&kio.ByteWriter{Writer: res}).Write(items); err != nil {
+		return nil, true, err
+	}
+	return res.Bytes(), true, nil
+}
+
+// renderKey returns bytes that uniquely identify a render: source, dependencies,
+// params, config and target all live in the input. It is JSON rather than YAML
+// because the params are already JSON, so this is a single cheap pass.
+func renderKey(in *fkcl.KCLInput) ([]byte, error) { return json.Marshal(in) }
+
+// isInlineSource mirrors the fallthrough branch of krm-kcl's SourceToTempEntry:
+// anything that is not a recognised remote or local location is inline KCL code.
+func isInlineSource(src string) bool {
+	return !source.IsOCI(src) &&
+		!source.IsLocal(src) &&
+		!source.IsRemoteUrl(src) &&
+		!source.IsGit(src) &&
+		!source.IsVCSDomain(src)
+}
+
+// kclArguments builds the KCL top-level arguments directly from the input. The
+// params are already JSON (runtime.RawExtension), so the payload is copied rather
+// than re-encoded.
+func kclArguments(in *fkcl.KCLInput) ([]string, error) {
+	// functionConfig is the KCLRun itself. RawExtension marshals as raw JSON, so
+	// this is a single pass over the payload.
+	fc, err := json.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+
+	params, err := paramsJSON(in)
+	if err != nil {
+		return nil, err
+	}
+
+	var rl bytes.Buffer
+	rl.WriteString(`{"apiVersion":"config.kubernetes.io/v1","kind":"ResourceList","items":[],"functionConfig":`)
+	rl.Write(fc)
+	rl.WriteByte('}')
+
+	env, err := envJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{
+		"resource_list=" + rl.String(),
+		"items=[]",
+		"params=" + string(params),
+		"PATH=" + os.Getenv("PATH"),
+		"env=" + string(env),
+	}, nil
+}
+
+// paramsJSON assembles {"oxr":<raw>,"dxr":<raw>,...} from the raw JSON we hold.
+// Keys are sorted so the result is deterministic.
+func paramsJSON(in *fkcl.KCLInput) ([]byte, error) {
+	keys := make([]string, 0, len(in.Spec.Params))
+	for k := range in.Spec.Params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b bytes.Buffer
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(kb)
+		b.WriteByte(':')
+		if raw := in.Spec.Params[k].Raw; len(raw) > 0 {
+			b.Write(raw)
+		} else {
+			b.WriteString("{}")
+		}
+	}
+	b.WriteByte('}')
+	return b.Bytes(), nil
+}
+
+func envJSON() ([]byte, error) {
+	m := make(map[string]string, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if kv := strings.SplitN(e, "=", 2); len(kv) == 2 {
+			m[kv[0]] = kv[1]
+		}
+	}
+	return json.Marshal(m)
+}

--- a/render_test.go
+++ b/render_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"kcl-lang.io/krm-kcl/pkg/api"
+	"kcl-lang.io/krm-kcl/pkg/api/v1alpha1"
+	krmkio "kcl-lang.io/krm-kcl/pkg/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/yaml"
+
+	fkcl "github.com/crossplane-contrib/function-kcl/input/v1alpha1"
+)
+
+// renderViaPipeline is the pre-existing path: marshal the input to YAML and let
+// the krm-kcl byte-stream pipeline parse it back. Kept here as the oracle the
+// fast path must agree with.
+func renderViaPipeline(t testing.TB, in *fkcl.KCLInput) []byte {
+	t.Helper()
+	b, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := bytes.NewBuffer(nil)
+	if err := krmkio.NewPipeline(bytes.NewBuffer(b), out, false).Execute(); err != nil {
+		t.Fatalf("krm-kcl pipeline: %v", err)
+	}
+	return out.Bytes()
+}
+
+// canonical renders KRM output into a stable, comparable form.
+func canonical(t testing.TB, b []byte) string {
+	t.Helper()
+	nodes, err := (&kio.ByteReader{Reader: bytes.NewBuffer(b), OmitReaderAnnotations: true}).Read()
+	if err != nil {
+		t.Fatalf("reading KRM output: %v", err)
+	}
+	docs := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		j, err := n.MarshalJSON()
+		if err != nil {
+			t.Fatalf("marshalling node: %v", err)
+		}
+		var v any
+		if err := json.Unmarshal(j, &v); err != nil {
+			t.Fatalf("unmarshalling node: %v", err)
+		}
+		c, err := json.Marshal(v) // re-marshal to sort map keys
+		if err != nil {
+			t.Fatalf("canonicalising node: %v", err)
+		}
+		docs = append(docs, string(c))
+	}
+	sort.Strings(docs)
+	return strings.Join(docs, "\n")
+}
+
+func mustRaw(t testing.TB, v any) runtime.RawExtension {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runtime.RawExtension{Raw: b}
+}
+
+// observed fabricates a composed resource whose status is padded to roughly
+// padBytes, standing in for a real Kubernetes resource with a chatty status.
+func observed(padBytes int) map[string]any {
+	conds := []any{}
+	for i := 0; len(fmt.Sprint(conds)) < padBytes && i < 500; i++ {
+		conds = append(conds, map[string]any{
+			"type":               fmt.Sprintf("Condition%d", i),
+			"status":             "True",
+			"reason":             "SomeReasonWithABitOfText",
+			"message":            "a message of the kind controllers like to write repeatedly",
+			"lastTransitionTime": "2024-01-01T00:00:00Z",
+		})
+	}
+	return map[string]any{
+		"resource": map[string]any{
+			"Resource": map[string]any{
+				"apiVersion": "example.org/v1",
+				"kind":       "Thing",
+				"metadata":   map[string]any{"name": "thing", "namespace": "default"},
+				"spec":       map[string]any{"replicas": 3},
+				"status":     map[string]any{"conditions": conds},
+			},
+			"Ready": "True",
+		},
+	}
+}
+
+func testInput(t testing.TB, source string, padBytes int) *fkcl.KCLInput {
+	t.Helper()
+	xr := map[string]any{
+		"apiVersion": "example.org/v1",
+		"kind":       "XR",
+		"metadata":   map[string]any{"name": "xr", "namespace": "default"},
+		"spec":       map[string]any{"replicas": 3, "name": "thing"},
+		"status":     map[string]any{},
+	}
+	cds := observed(padBytes)
+
+	in := &fkcl.KCLInput{}
+	in.APIVersion = v1alpha1.KCLRunAPIVersion
+	in.Kind = api.KCLRunKind
+	in.Name = "test"
+	in.Spec.Source = source
+	in.Spec.Target = "Default"
+	in.Spec.Params = map[string]runtime.RawExtension{
+		"oxr":               mustRaw(t, xr),
+		"dxr":               mustRaw(t, xr),
+		"ocds":              mustRaw(t, cds),
+		"dcds":              mustRaw(t, cds),
+		"ctx":               mustRaw(t, map[string]any{"apiextensions.crossplane.io/environment": map[string]any{"region": "eu"}}),
+		"extraResources":    mustRaw(t, map[string]any{}),
+		"requiredResources": mustRaw(t, map[string]any{}),
+	}
+	return in
+}
+
+const (
+	// Emits a resource built from params.
+	srcEmit = `
+oxr = option("params").oxr
+items = [{
+    apiVersion = "example.org/v1"
+    kind = "Thing"
+    metadata.name = str(oxr.spec.name)
+    spec.replicas = int(oxr.spec.replicas)
+}]
+`
+	// Reads the observed composed state.
+	srcReadObserved = `
+ocds = option("params")?.ocds or {}
+ready = "resource" in ocds and str(ocds["resource"]?.Ready or "") == "True"
+items = [{
+    apiVersion = "example.org/v1"
+    kind = "Thing"
+    metadata.name = "thing"
+    metadata.annotations = {"ready" = str(ready)}
+}]
+`
+	// Emits nothing.
+	srcEmpty = `
+items = []
+`
+	// Reads the function context.
+	srcContext = `
+ctx = option("params").ctx
+env = ctx?["apiextensions.crossplane.io/environment"] or {}
+items = [{
+    apiVersion = "example.org/v1"
+    kind = "Thing"
+    metadata.name = "thing"
+    metadata.labels = {"region" = str(env?.region or "")}
+}]
+`
+)
+
+// TestRenderInlineMatchesPipeline is the core guarantee: for inline sources the
+// fast path must produce exactly what the krm-kcl pipeline produces.
+func TestRenderInlineMatchesPipeline(t *testing.T) {
+	cases := map[string]string{
+		"emit":          srcEmit,
+		"read-observed": srcReadObserved,
+		"empty":         srcEmpty,
+		"context":       srcContext,
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			in := testInput(t, src, 2000)
+
+			want := canonical(t, renderViaPipeline(t, in))
+
+			got, ok, err := renderInline(in)
+			if err != nil {
+				t.Fatalf("renderInline: %v", err)
+			}
+			if !ok {
+				t.Fatal("renderInline declined an inline source")
+			}
+			if g := canonical(t, got); g != want {
+				t.Errorf("output differs\n--- pipeline ---\n%s\n\n--- fast path ---\n%s", want, g)
+			}
+		})
+	}
+}
+
+// TestRenderInlineDeclinesNonInlineSources: anything that is not inline code must
+// fall back to the krm-kcl pipeline, which knows how to fetch it.
+func TestRenderInlineDeclinesNonInlineSources(t *testing.T) {
+	for _, src := range []string{
+		"oci://ghcr.io/kcl-lang/set-annotations",
+		"https://example.com/prog.k",
+		"git::https://github.com/kcl-lang/krm-kcl",
+		"github.com/kcl-lang/krm-kcl",
+		"./local/prog.k",
+	} {
+		t.Run(src, func(t *testing.T) {
+			in := testInput(t, src, 0)
+			if _, ok, err := renderInline(in); ok || err != nil {
+				t.Errorf("expected fall back to the pipeline, got ok=%v err=%v", ok, err)
+			}
+		})
+	}
+}
+
+// BenchmarkRender shows the cost is dominated by the payload, not by the KCL.
+func BenchmarkRender(b *testing.B) {
+	for _, pad := range []int{0, 50_000, 200_000} {
+		in := testInput(b, srcEmit, pad)
+		size := len(mustMarshal(b, in)) / 1024
+
+		b.Run(fmt.Sprintf("pipeline/input=%dKB", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				renderViaPipeline(b, in)
+			}
+		})
+		b.Run(fmt.Sprintf("inline/input=%dKB", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, _, err := renderInline(in); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func mustMarshal(t testing.TB, in *fkcl.KCLInput) []byte {
+	t.Helper()
+	b, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}


### PR DESCRIPTION
Ref: https://github.com/crossplane-contrib/function-kcl/issues/407

### What does this PR do?

Renders inline KCL by handing the runtime the JSON we already hold, instead of converting it to YAML and back first.

`RunFunction` builds `in.Spec.Params` as `runtime.RawExtension` — i.e. **JSON** — then serializes the whole `KCLInput` to YAML (`fn.go:209`), hands it to the krm-kcl byte-stream pipeline, which parses it back into kyaml `RNode`s, and finally re-serializes those `RNode`s to JSON (`krm-kcl/pkg/edit/opts.go`, `ToKCLValueString`) to build the KCL top-level arguments:

```
 fn.go
   observed / desired  ──json.Marshal──▶  RawExtension{Raw: []byte}     ❶  we have JSON
                                                    │
 fn.go:209                                          ▼
   KCLRun YAML document                                                 ❷  JSON ▶ YAML
                                                    │
 krm-kcl  pkg/kio                                   ▼
   kyaml RNode tree                                                     ❸  YAML ▶ parse
                                                    │
 krm-kcl  pkg/edit/opts.go                          ▼
   -D resource_list=<JSON>  -D items=<JSON>  -D params=<JSON>           ❹  RNode ▶ JSON
                                                    │
 kcl-lang.io/lib                                    ▼
   Rust libkcl: parse the JSON args, compile, evaluate                  ❺  wants JSON
```

We hold JSON at ❶ and the runtime wants JSON at ❺. **❷–❸–❹ is pure conversion.**

It is not a rounding error. For compositions whose observed state is large — a Kubernetes resource with a fat `status` subresource, which is the norm — that conversion dominates the call. CPU profile of a 164 KB input on the current path:

| | share of CPU |
|---|---|
| `runtime.cgocall` — the entire native KCL compile + eval | **10.4 %** |
| YAML parsing (`go.yaml.in/yaml/v3`) | 22 % |
| `ToKCLValueString` (RNode → JSON) | 21 % |
| `runtime.gcBgMarkWorker` — GC from the allocation churn | 24 % |

A 164 KB input was allocating **87 MB per call**.

### Approach

`renderInline` (new `render.go`) assembles the KCL arguments straight from the input bytes and calls the KCL runtime via `kcl-lang.io/cli`'s `RunOptions` — the same options object krm-kcl builds, just without the detour. Output handling is unchanged: KCL emits every top-level variable, and we unwrap `items` with krm-kcl's own `edit.UnwrapResources`, exactly as `SimpleTransformer.Transform` does.

It handles **inline `source`**, which is the common case for Crossplane compositions. Anything else — `oci://`, git, http(s), a local path — returns `ok == false` and `RunFunction` falls back to the existing krm-kcl pipeline, which knows how to fetch those. The inline test mirrors the fallthrough branch of krm-kcl's `SourceToTempEntry`, so the two agree on what "inline" means. `spec.dependencies` are resolved on the fast path via krm-kcl's `edit.LoadDepListFromConfig`, so setting them does not disable it.

Nothing in krm-kcl or kcl-lang/kcl has to change: every symbol used here (`edit.UnwrapResources`, `edit.LoadDepListFromConfig`, `source.IsOCI` and friends, `options.RunOptions`) is already exported.

### Results

```
BenchmarkRender/pipeline/input=1KB       3.9 ms/op    1.8 MB/op    10385 allocs/op
BenchmarkRender/inline/input=1KB         1.2 ms/op    0.1 MB/op     1233 allocs/op

BenchmarkRender/pipeline/input=140KB    83.8 ms/op   58.8 MB/op   325755 allocs/op
BenchmarkRender/inline/input=140KB       7.5 ms/op    1.6 MB/op     1243 allocs/op

BenchmarkRender/pipeline/input=243KB   134.9 ms/op  100.0 MB/op   557705 allocs/op
BenchmarkRender/inline/input=243KB      12.5 ms/op    2.6 MB/op     1241 allocs/op
```

**~11× faster at a realistic payload, and allocations become independent of payload size** (1 243 allocs whether the input is 1 KB or 243 KB, versus 557 705). After the change the remaining time is ~64 % inside the KCL runtime itself, which is where it belongs.

Real-world motivation: a CloudNativePG composition with 21 KCL steps across 90 XRs, where `function-kcl` pods sit pegged at their CPU limit.

### Correctness

- `TestRenderInlineMatchesPipeline` renders the same inputs through both paths and asserts the resulting resources are identical (canonicalised KRM). Covers emitting resources, reading `ocds`, reading `ctx`, and emitting nothing.
- `TestRenderInlineDeclinesNonInlineSources` asserts `oci://`, http(s), git, VCS-domain and local sources all fall back.
- The full existing suite (98 tests) passes unchanged, with the fast path on by default.

### Notes for reviewers

- The fast path duplicates a small amount of krm-kcl's argument construction. The cleaner long-term home is arguably an API in `krm-kcl` that accepts pre-serialized JSON — happy to move it there instead if you prefer, though that turns this into a two-repo change.
- The render cache key moves from the YAML bytes to `json.Marshal(in)` (`renderKey`). Same identifying content — source, dependencies, params, config, target — one cheap pass instead of a YAML serialization that the fast path no longer performs.
- The two remaining costs on this path, both out of scope here: `option("params")` is populated with all seven params unconditionally even when the source never reads them, and `resource_list` embeds the params that are then passed again as `params`, so the payload still travels twice.

I have:

- [/] Read and followed Crossplane's [contribution process].
- [/] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
