### PR TITLE
perf: run inline KCL without a temp file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/apimachinery v0.36.2
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
 	kcl-lang.io/cli v0.12.7
+	kcl-lang.io/kcl-go v0.12.3
 	kcl-lang.io/kpm v0.12.8
 	kcl-lang.io/krm-kcl v0.12.7
 	oras.land/oras-go/v2 v2.6.2
@@ -252,7 +253,6 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20251215205346-5ee0d033ba5b // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260427204847-8949caaa1199 // indirect
-	kcl-lang.io/kcl-go v0.12.3 // indirect
 	kcl-lang.io/kcl-openapi v0.10.2 // indirect
 	kcl-lang.io/lib v0.12.3 // indirect
 	sigs.k8s.io/controller-runtime v0.24.0 // indirect

--- a/render.go
+++ b/render.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"kcl-lang.io/cli/pkg/options"
+	"kcl-lang.io/kcl-go/pkg/kcl"
 	"kcl-lang.io/kpm/pkg/client"
 	"kcl-lang.io/krm-kcl/pkg/edit"
 	"kcl-lang.io/krm-kcl/pkg/source"
@@ -53,23 +54,73 @@ func renderInline(in *fkcl.KCLInput) (out []byte, ok bool, err error) {
 		}
 	}
 
-	dir, err := os.MkdirTemp("", "kcl-sandbox")
-	if err != nil {
-		return nil, true, err
-	}
-	defer os.RemoveAll(dir)
-
-	prog := filepath.Join(dir, "prog.k")
-	if err := os.WriteFile(prog, []byte(in.Spec.Source), 0o600); err != nil {
-		return nil, true, err
-	}
-
 	args, err := kclArguments(in)
 	if err != nil {
 		return nil, true, err
 	}
 
 	buf := bytes.NewBuffer(nil)
+	if !in.Spec.Config.Vendor {
+		opts := []kcl.Option{
+			kcl.WithCode(in.Spec.Source),
+			kcl.WithOptions(args...),
+			kcl.WithExternalPkgs(dependencies...),
+		}
+		for _, setting := range in.Spec.Config.Settings {
+			opts = append(opts, kcl.WithSettings(setting))
+		}
+		exec := kcl.NewOption()
+		exec.Overrides = in.Spec.Config.Overrides
+		exec.PathSelector = in.Spec.Config.PathSelectors
+		exec.DisableNone = in.Spec.Config.DisableNone
+		exec.Debug = boolToInt32(in.Spec.Config.Debug)
+		exec.SortKeys = in.Spec.Config.SortKeys
+		exec.ShowHidden = in.Spec.Config.ShowHidden
+		exec.StrictRangeCheck = in.Spec.Config.StrictRangeCheck
+		opts = append(opts, *exec)
+
+		result, err := kcl.Run("prog.k", opts...)
+		if err != nil {
+			return nil, true, err
+		}
+		buf.WriteString(result.GetRawYamlResult())
+	} else {
+		if err := renderInlineVendor(in, dependencies, args, buf); err != nil {
+			return nil, true, err
+		}
+	}
+
+	// KCL emits every top-level variable; krm-kcl's contract is that the resources
+	// live under `items`. Unwrap exactly as SimpleTransformer.Transform does. This
+	// operates on the output, which is small — the saving is all on the input side.
+	nodes, err := (&kio.ByteReader{Reader: buf, OmitReaderAnnotations: true}).Read()
+	if err != nil {
+		return nil, true, err
+	}
+	items, _, err := edit.UnwrapResources(nodes)
+	if err != nil {
+		return nil, true, err
+	}
+
+	res := bytes.NewBuffer(nil)
+	if err := (&kio.ByteWriter{Writer: res}).Write(items); err != nil {
+		return nil, true, err
+	}
+	return res.Bytes(), true, nil
+}
+
+func renderInlineVendor(in *fkcl.KCLInput, dependencies, args []string, buf *bytes.Buffer) error {
+	dir, err := os.MkdirTemp("", "kcl-sandbox")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	prog := filepath.Join(dir, "prog.k")
+	if err := os.WriteFile(prog, []byte(in.Spec.Source), 0o600); err != nil {
+		return err
+	}
+
 	opts := options.NewRunOptions()
 	opts.NoStyle = true
 	opts.Entries = []string{prog}
@@ -92,32 +143,22 @@ func renderInline(in *fkcl.KCLInput) (out []byte, ok bool, err error) {
 	}
 
 	if err := opts.Complete([]string{}); err != nil {
-		return nil, true, err
+		return err
 	}
 	if err := opts.Validate(); err != nil {
-		return nil, true, err
+		return err
 	}
 	if err := opts.Run(); err != nil {
-		return nil, true, err
+		return err
 	}
+	return nil
+}
 
-	// KCL emits every top-level variable; krm-kcl's contract is that the resources
-	// live under `items`. Unwrap exactly as SimpleTransformer.Transform does. This
-	// operates on the output, which is small — the saving is all on the input side.
-	nodes, err := (&kio.ByteReader{Reader: buf, OmitReaderAnnotations: true}).Read()
-	if err != nil {
-		return nil, true, err
+func boolToInt32(v bool) int32 {
+	if v {
+		return 1
 	}
-	items, _, err := edit.UnwrapResources(nodes)
-	if err != nil {
-		return nil, true, err
-	}
-
-	res := bytes.NewBuffer(nil)
-	if err := (&kio.ByteWriter{Writer: res}).Write(items); err != nil {
-		return nil, true, err
-	}
-	return res.Bytes(), true, nil
+	return 0
 }
 
 // renderKey returns bytes that uniquely identify a render: source, dependencies,

--- a/render_test.go
+++ b/render_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -210,6 +212,25 @@ func TestRenderInlineDeclinesNonInlineSources(t *testing.T) {
 				t.Errorf("expected fall back to the pipeline, got ok=%v err=%v", ok, err)
 			}
 		})
+	}
+}
+
+func TestRenderInlineDoesNotCreateTempFile(t *testing.T) {
+	notDir := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(notDir, []byte("block temp files"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMPDIR", notDir)
+
+	got, ok, err := renderInline(testInput(t, srcEmit, 0))
+	if err != nil {
+		t.Fatalf("renderInline: %v", err)
+	}
+	if !ok {
+		t.Fatal("renderInline declined an inline source")
+	}
+	if canonical(t, got) == "" {
+		t.Fatal("renderInline returned no resources")
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

Follow-up to #407 and #408. The inline fast path still created and removed a temporary `prog.k` file for every render even though the KCL API accepts source through `KCodeList`.

This change runs non-vendor inline sources through `kcl.WithCode`, preserving arguments, dependencies, settings, overrides, selectors, and compile flags. Vendor mode keeps the existing CLI-backed path because its package-resolution semantics are CLI-specific.

`TestRenderInlineDoesNotCreateTempFile` sets `TMPDIR` to a regular file, which makes the previous implementation fail at `os.MkdirTemp`, and verifies the in-memory path still renders a resource. The existing pipeline-equivalence tests continue to pass.

Refs #407

### Verification

- `go test -count=1 -run "TestRenderInline(MatchesPipeline|DeclinesNonInlineSources|DoesNotCreateTempFile)$" -v .`
- `GOMAXPROCS=8 go test -p 8 -count=1 -cover ./...`
- `GOMAXPROCS=8 go vet ./...`
- `go mod tidy && git diff --exit-code go.mod go.sum`
- `git diff --check`

### Disclosure

This contribution was prepared with assistance from OpenAI Codex. I reviewed the implementation, tests, and submitted diff.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute