### PR TITLE
fix: fail fast on composed resources with no composition resource name

### DIFF
--- a/fn_test.go
+++ b/fn_test.go
@@ -120,7 +120,7 @@ func TestRunFunctionSimple(t *testing.T) {
 						},
 						"spec": {
 							"target": "Resources",
-							"source": "{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n}"
+							"source": "{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n    metadata.name = \"generated\"\n}"
 						}
 					}`),
 					Observed: &fnv1.State{
@@ -138,8 +138,8 @@ func TestRunFunctionSimple(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1.Resource{
-							"": {
-								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated"}`),
+							"generated": {
+								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated","metadata":{"name":"generated"}}`),
 							},
 						},
 					},
@@ -158,7 +158,7 @@ func TestRunFunctionSimple(t *testing.T) {
 							"name": "basic"
 						},
 						"spec": {
-							"source": "items = [{ \n    apiVersion: \"sql.gcp.upbound.io/v1beta1\"\n    kind: \"DatabaseInstance\"\n    spec: {\n        forProvider: {\n            project: \"test-project\"\n            settings: [{databaseFlags: [{\n                name: \"log_checkpoints\"\n                value: \"on\"\n            }]}]\n        }\n    }\n}]\n"
+							"source": "items = [{ \n    apiVersion: \"sql.gcp.upbound.io/v1beta1\"\n    kind: \"DatabaseInstance\"\n    metadata.name = \"database-instance\"\n    spec: {\n        forProvider: {\n            project: \"test-project\"\n            settings: [{databaseFlags: [{\n                name: \"log_checkpoints\"\n                value: \"on\"\n            }]}]\n        }\n    }\n}]\n"
 						}
 					}`),
 					Observed: &fnv1.State{
@@ -176,8 +176,8 @@ func TestRunFunctionSimple(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1.Resource{
-							"": {
-								Resource: resource.MustStructJSON(`{"apiVersion": "sql.gcp.upbound.io/v1beta1", "kind": "DatabaseInstance", "spec": {"forProvider": {"project": "test-project", "settings": [{"databaseFlags": [{"name": "log_checkpoints", "value": "on"}]}]}}}`),
+							"database-instance": {
+								Resource: resource.MustStructJSON(`{"apiVersion": "sql.gcp.upbound.io/v1beta1", "kind": "DatabaseInstance", "metadata": {"name": "database-instance"}, "spec": {"forProvider": {"project": "test-project", "settings": [{"databaseFlags": [{"name": "log_checkpoints", "value": "on"}]}]}}}`),
 							},
 						},
 					},
@@ -722,7 +722,7 @@ func TestRunFunctionSimple(t *testing.T) {
 		},
 		"EmptyInputWithDefaultSource": {
 			reason:        "The function should use the default source when input is not provided and default source is set",
-			defaultSource: "{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n}",
+			defaultSource: "{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n    metadata.name = \"generated\"\n}",
 			args: args{
 				req: &fnv1.RunFunctionRequest{
 					Meta:  &fnv1.RequestMeta{Tag: "empty-input"},
@@ -742,8 +742,8 @@ func TestRunFunctionSimple(t *testing.T) {
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
 						},
 						Resources: map[string]*fnv1.Resource{
-							"": {
-								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated"}`),
+							"generated": {
+								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated","metadata":{"name":"generated"}}`),
 							},
 						},
 					},

--- a/pkg/resource/res.go
+++ b/pkg/resource/res.go
@@ -587,6 +587,14 @@ func (c *duplicateChecker) CheckAndSetDesired(desired map[resource.Name]*resourc
 
 func (c *duplicateChecker) CheckDuplicateName(cd *resource.DesiredComposed, name resource.Name) error {
 	kindAndName := cd.Resource.GetKind() + "/" + cd.Resource.GetName()
+	// A composed resource with neither metadata.name nor the composition
+	// resource name annotation would be keyed on the empty string here, and
+	// Crossplane later rejects it with an opaque "composed resource without
+	// required composition-resource-name" error. Fail fast instead, naming
+	// the resource that is missing a name.
+	if name == "" {
+		return errors.Errorf("composed resource of kind %q has no composition resource name: set metadata.name or metadata.annotations.%q to give it a stable identity", cd.Resource.GetKind(), AnnotationKeyCompositionResourceName)
+	}
 	if _, existed := (*c)[name]; existed {
 		return errors.Errorf("multiple composed resources with name %q returned: %s and %s. Set different metadata.name or metadata.annotations.\"krm.kcl.dev/composition-resource-name\" to distinguish them.", name, (*c)[name], kindAndName)
 	}

--- a/pkg/resource/res_test.go
+++ b/pkg/resource/res_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"strings"
 	"testing"
 
 	res "github.com/crossplane/function-sdk-go/resource"
@@ -122,6 +123,83 @@ func TestSetData(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.args.o, tt.expected); diff != "" {
 				t.Errorf("SetData(): -want rsp, +got rsp:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCheckDuplicateName(t *testing.T) {
+	newCD := func(kind, name, annotation string) *res.DesiredComposed {
+		metadata := map[string]interface{}{}
+		if name != "" {
+			metadata["name"] = name
+		}
+		if annotation != "" {
+			metadata["annotations"] = map[string]interface{}{
+				AnnotationKeyCompositionResourceName: annotation,
+			}
+		}
+		return &res.DesiredComposed{
+			Resource: &composed.Unstructured{
+				Unstructured: unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "example.org/v1",
+						"kind":       kind,
+						"metadata":   metadata,
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		kind    string
+		objName string
+		annot   string
+		wantErr string
+	}{
+		{
+			name:    "Named via metadata.name is accepted",
+			kind:    "Bucket",
+			objName: "my-bucket",
+		},
+		{
+			name:  "Named via the composition resource name annotation is accepted",
+			kind:  "Bucket",
+			annot: "bucket",
+		},
+		{
+			// Without this guard the resource is keyed on "" and Crossplane
+			// later fails with an opaque "composed resource without required
+			// composition-resource-name" error. See issue #199.
+			name:    "Unnamed resource is rejected with an actionable error",
+			kind:    "Release",
+			wantErr: `composed resource of kind "Release" has no composition resource name`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cd := newCD(tt.kind, tt.objName, tt.annot)
+			checker := newDuplicateChecker()
+			err := checker.CheckDuplicateName(cd, res.Name(GetResourceName(cd)))
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckDuplicateName() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckDuplicateName() expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("CheckDuplicateName() error = %q, want it to contain %q", err, tt.wantErr)
+			}
+			// The message must point the author at the annotation to set.
+			if !strings.Contains(err.Error(), AnnotationKeyCompositionResourceName) {
+				t.Errorf("CheckDuplicateName() error = %q, want it to mention %q", err, AnnotationKeyCompositionResourceName)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #199.

A composed resource that sets neither `metadata.name` nor the
`krm.kcl.dev/composition-resource-name` annotation resolves to the **empty
string** in `GetResourceName`, and is keyed on `""` in the desired map:

```go
name, found := cd.Resource.GetAnnotations()[AnnotationKeyCompositionResourceName]
if !found {
    name = cd.Resource.GetName()   // metadata.name -- may also be unset
}
```

function-kcl passed that straight through, and Crossplane rejected it
downstream with

```
encountered composed resource without required "crossplane.io/composition-resource-name"
```

which names neither the offending resource nor what the author should set. That
is exactly the confusion in #199, where the reporter reasonably asked whether
the missing name was a bug — and then got no answer for a year.

## Approach

The behaviour is correct: function-kcl **cannot** synthesise a name here. The
composition resource name is the stable identity key Crossplane uses to
correlate desired resources across reconciles, so a generated one (index, hash,
counter) would shift whenever the list order or length changed and Crossplane
would delete and recreate real infrastructure. It has to come from the author.

So this only fixes the **diagnostics**. `CheckDuplicateName` is the single choke
point both naming paths already flow through (the `Resources` merge path and
`CheckAndSetDesired`), so the guard goes there and returns an error naming the
offending kind and the annotation to set:

```
composed resource of kind "Release" has no composition resource name:
set metadata.name or metadata.annotations."krm.kcl.dev/composition-resource-name"
to give it a stable identity
```

Empty is never a valid composition resource name — Crossplane always rejects it
— so nothing that previously worked stops working. This strictly converts an
opaque downstream failure into an actionable upstream one.

## Note for reviewers: three existing tests changed

`ResponseIsReturned`, `DatabaseInstance` and `EmptyInputWithDefaultSource`
emitted metadata-less resources and asserted they landed under the `""` key.
That was incidental to what each actually covers (a response is returned / the
default source is used / nested lists are handled) rather than a deliberate
assertion about empty naming — their `reason` strings are copy-pasted and two of
them do not even describe what they test. They now give their resources a name,
as a real composition must.

**This is the one judgement call in the PR** — if you would rather keep
pass-through behaviour and emit a warning result instead of an error, say so and
I will rework it.

## Test plan

- [x] `TestCheckDuplicateName` added in `pkg/resource/res_test.go`, covering
      named-via-`metadata.name`, named-via-annotation, and the unnamed case;
      it asserts the message both names the kind and mentions the annotation.
- [x] Verified the new test **fails without the guard** (`got nil`) and passes
      with it, so it is a real regression test rather than a tautology.
- [x] `go test ./...` green on top of current `main`.
- [x] `gofmt` / `go vet` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)