### PR TITLE
feat: allow spec.ttl to override the function response TTL (fixes #392)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,29 @@ spec:
     # omit other fields
 ```
 
+### Custom Function Response TTL
+
+By default the function asks Crossplane to re-run it after
+`response.DefaultTTL` (60s). You can override that on a per-Composition basis
+with `spec.ttl`, which sets `response.meta.ttl` on the function response.
+Accepts Kubernetes duration strings (e.g. `"90s"`, `"5m"`, `"1h"`). Setting
+`"0s"` requests an immediate requeue after the current reconcile loop, which
+is useful when the function is waiting on an external condition it has not yet
+observed (see [#392](https://github.com/crossplane-contrib/function-kcl/issues/392)).
+
+```yaml
+apiVersion: krm.kcl.dev/v1alpha1
+kind: KCLInput
+spec:
+  source: |
+    items = [...]
+  ttl: 10m   # requeue this function every 10 minutes
+```
+
+Note: `spec.ttl` only changes the function response TTL; the in-process render
+cache is controlled separately via the `FUNCTION_KCL_RENDER_CACHE_TTL` and
+`FUNCTION_KCL_RENDER_CACHE_SIZE` environment variables.
+
 ### Dependencies
 
 ```yaml

--- a/fn.go
+++ b/fn.go
@@ -13,6 +13,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"k8s.io/apimachinery/pkg/runtime"
 	"kcl-lang.io/krm-kcl/pkg/api"
@@ -66,6 +67,19 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	if err := request.GetInput(req, in); err != nil {
 		response.Fatal(rsp, errors.Wrapf(err, "cannot get Function input from %T", req))
 		return rsp, nil
+	}
+	// Allow callers to override the function response TTL via spec.ttl. When
+	// unset we keep the Crossplane default so existing compositions behave the
+	// same. Negative durations are clamped to 0 — Crossplane treats 0 as
+	// "requeue immediately after the current reconcile finishes", which is
+	// useful for waiting on conditions this function has not yet observed.
+	if in.Spec.TTL != nil {
+		ttl := in.Spec.TTL.Duration
+		if ttl < 0 {
+			ttl = 0
+		}
+		log.Debug("using custom function response TTL", "ttl", ttl.String())
+		rsp.Meta.Ttl = durationpb.New(ttl)
 	}
 	// Set default source
 	if in.Spec.Source == "" {

--- a/fn_test.go
+++ b/fn_test.go
@@ -184,6 +184,86 @@ func TestRunFunctionSimple(t *testing.T) {
 				},
 			},
 		},
+		"CustomTTLIsHonoured": {
+			reason: "spec.ttl should override the default function response TTL.",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "custom-ttl"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "krm.kcl.dev/v1alpha1",
+						"kind": "KCLInput",
+						"metadata": {
+							"name": "basic"
+						},
+						"spec": {
+							"target": "Resources",
+							"source": "{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n    metadata.name = \"generated\"\n}",
+							"ttl": "5m"
+						}
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "custom-ttl", Ttl: durationpb.New(5 * time.Minute)},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+						Resources: map[string]*fnv1.Resource{
+							"generated": {
+								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated","metadata":{"name":"generated"}}`),
+							},
+						},
+					},
+				},
+			},
+		},
+		"CustomTTLZeroRequeuesImmediately": {
+			reason: "spec.ttl = 0s should be honoured and request an immediate requeue (no wait).",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "custom-ttl-zero"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "krm.kcl.dev/v1alpha1",
+						"kind": "KCLInput",
+						"metadata": {
+							"name": "basic"
+						},
+						"spec": {
+							"target": "Resources",
+							"source": "{\n    apiVersion: \"example.org/v1\"\n    kind: \"Generated\"\n    metadata.name = \"generated\"\n}",
+							"ttl": "0s"
+						}
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "custom-ttl-zero", Ttl: durationpb.New(0)},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+						Resources: map[string]*fnv1.Resource{
+							"generated": {
+								Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"Generated","metadata":{"name":"generated"}}`),
+							},
+						},
+					},
+				},
+			},
+		},
 		"CustomCompositionResourceNameIsSet": {
 			reason: "The Function should set value of crossplane.io/composition-resource-name annotation by krm.kcl.dev/composition-resource-name annotation ",
 			args: args{

--- a/input/v1alpha1/input.go
+++ b/input/v1alpha1/input.go
@@ -75,6 +75,15 @@ type RunSpec struct {
 	// +kubebuilder:default:=Resources
 	// +kubebuilder:validation:Enum:=Default;PatchDesired;PatchResources;Resources;XR
 	Target resource.Target `json:"target"`
+	// TTL overrides the function response cache TTL (response.meta.ttl) returned
+	// to Crossplane for this run. When unset, the Crossplane function SDK default
+	// (response.DefaultTTL) is used. The duration string follows Kubernetes
+	// conventions, e.g. "90s", "5m", "1h". A value of 0 means Crossplane will
+	// retry this function as soon as the current reconcile loop completes, which
+	// can be useful to intentionally requeue (e.g. when waiting on an external
+	// condition that this function has not yet observed).
+	// +optional
+	TTL *metav1.Duration `json:"ttl,omitempty" yaml:"ttl,omitempty"`
 }
 
 // ConfigSpec defines the compile config.

--- a/input/v1alpha1/zz_generated.deepcopy.go
+++ b/input/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -143,6 +144,11 @@ func (in *RunSpec) DeepCopyInto(out *RunSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.TTL != nil {
+		in, out := &in.TTL, &out.TTL
+		*out = new(v1.Duration)
+		**out = **in
 	}
 }
 

--- a/package/input/krm.kcl.dev_kclinputs.yaml
+++ b/package/input/krm.kcl.dev_kclinputs.yaml
@@ -152,6 +152,16 @@ spec:
                 - Resources
                 - XR
                 type: string
+              ttl:
+                description: |-
+                  TTL overrides the function response cache TTL (response.meta.ttl) returned
+                  to Crossplane for this run. When unset, the Crossplane function SDK default
+                  (response.DefaultTTL) is used. The duration string follows Kubernetes
+                  conventions, e.g. "90s", "5m", "1h". A value of 0 means Crossplane will
+                  retry this function as soon as the current reconcile loop completes, which
+                  can be useful to intentionally requeue (e.g. when waiting on an external
+                  condition that this function has not yet observed).
+                type: string
             required:
             - source
             - target


### PR DESCRIPTION
## Summary

Implements the request from #392: a per-Composition override for the function response cache TTL (the value that Crossplane uses to decide when to re-run the function).

Add an optional `spec.ttl` field on `KCLInput.spec` that takes a Kubernetes duration string (e.g. `"90s"`, `"5m"`, `"1h"`). When set it replaces `response.DefaultTTL` (60s) with the supplied duration. `"0s"` requests an immediate requeue, which is useful when this function is waiting on an external condition it has not yet observed.

## What changed

- `input/v1alpha1/input.go` — new `*metav1.Duration` `TTL` field on `RunSpec` (`omitempty`, `+optional`).
- `input/v1alpha1/zz_generated.deepcopy.go` — regenerated via controller-gen v0.19.0 (matches existing style).
- `package/input/krm.kcl.dev_kclinputs.yaml` — regenerated CRD schema with the new field.
- `fn.go` — when `Spec.TTL` is set, override `rsp.Meta.Ttl`. Negative values are clamped to 0.
- `fn_test.go` — adds two regression tests:
  - `CustomTTLIsHonoured` — `ttl: "5m"` produces `5m` on the response.
  - `CustomTTLZeroRequeuesImmediately` — `ttl: "0s"` produces a zero TTL.
- `README.md` — new "Custom Function Response TTL" section under the Configuration docs that documents the field and notes the separation between `spec.ttl` (response cache) and the existing `FUNCTION_KCL_RENDER_CACHE_TTL` env var (in-process render cache).

## Example

```yaml
apiVersion: krm.kcl.dev/v1alpha1
kind: KCLInput
spec:
  source: |
    items = [...]
  ttl: 10m   # requeue this function every 10 minutes
```

## Notes

- This is purely additive; existing compositions that omit `spec.ttl` continue to use `response.DefaultTTL`.
- The fix is local to function-kcl. It does not require any change to the underlying `kcl-lang.io/cli`, `krm-kcl`, or `kpm` packages.

## Test plan

- [x] `go test -count=1 ./...` passes locally (incl. two new TTL tests).
- [x] `go vet ./...` clean.
- [x] CRD/deepcopy regenerated with controller-gen v0.19.0 (matches CI toolchain).
- [ ] CI green on the PR.