### PR TITLE
feat(credentials): add provider field for passwordless OCI login

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,15 @@ spec:
     url: https://<oci-host-url> # or KCL_SRC_URL environment variable
     username: <username> # or KCL_SRC_USERNAME environment variable
     password: <password> # or KCL_SRC_PASSWORD environment variable
+    # Optional. When set, kpm's `--provider` flag is used to mint the
+    # OCI credential instead of `username/password`. Supported values:
+    #   "" / "basic" — Username/Password are used as-is (default).
+    #   "gcp"        — OAuth2 access token is fetched from the GCE/GKE
+    #                  metadata server (Workload Identity). Username
+    #                  and Password are ignored. Useful for GKE pods
+    #                  that should pull from Artifact Registry without
+    #                  any static credential.
+    provider: "" # optional
 ```
 
 You can provide credentials in a Secret to your pipeline step under the name `kcl-registry`.
@@ -367,6 +376,11 @@ data:
   username: dXNlcm5hbWU=
   password: cGFzc3dvcmQ=
   url: aHR0cHM6Ly9leGFtcGxlLmNvbQ==
+  # Optional. Set to "gcp" to authenticate via GCP Workload Identity
+  # (no static credential needed when the function runs in a GKE pod
+  # with Workload Identity bound). Leave unset for the basic
+  # username/password flow.
+  # provider: Z2Nw
 ```
 
 You can use these credentials with `crossplane render --function-credentials=secret.yaml xr.yaml composition.yaml functions.yaml`.

--- a/fn.go
+++ b/fn.go
@@ -112,8 +112,18 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 				if url, ok := data.Data["url"]; ok {
 					in.Spec.Credentials.Url = string(url)
 				}
+			} else if _, hasProvider := data.Data["provider"]; hasProvider {
+				// No password is required when a provider is
+				// configured: the provider mints the credential
+				// (e.g. GCP Workload Identity).
+				if url, ok := data.Data["url"]; ok {
+					in.Spec.Credentials.Url = string(url)
+				}
 			} else {
 				log.Info("Warning: required password not found in the credentials")
+			}
+			if provider, ok := data.Data["provider"]; ok {
+				in.Spec.Credentials.Provider = string(provider)
 			}
 		}
 	}
@@ -376,4 +386,3 @@ func resetOCITokenCacheIfNeeded(log logging.Logger) {
 		log.Debug("Reset ORAS OCI token cache", "age", age.Round(time.Second), "maxAge", ociCacheMaxAge)
 	}
 }
-

--- a/fn_test.go
+++ b/fn_test.go
@@ -264,6 +264,57 @@ func TestRunFunctionSimple(t *testing.T) {
 				},
 			},
 		},
+		"CredentialsProviderFlowsThrough": {
+			reason: "Spec.Credentials.Provider must be populated from the kcl-registry credential data so downstream consumers (krm-kcl, kpm) can dispatch on it.",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "creds-provider"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "krm.kcl.dev/v1alpha1",
+						"kind": "KCLInput",
+						"metadata": {
+							"name": "basic"
+						},
+						"spec": {
+							"target": "Resources",
+							"source": "_creds = option(\"resource_list\")?.functionConfig?.spec?.credentials or {}\nitems = [{\n    apiVersion: \"v1\"\n    kind: \"ConfigMap\"\n    metadata.name = \"creds\"\n    data: {\n        provider = _creds.provider or \"\"\n        url = _creds.url or \"\"\n    }\n}]"
+						}
+					}`),
+					Credentials: map[string]*fnv1.Credentials{
+						"kcl-registry": {
+							Source: &fnv1.Credentials_CredentialData{
+								CredentialData: &fnv1.CredentialData{
+									Data: map[string][]byte{
+										"url":      []byte("gcr.io/my-project"),
+										"provider": []byte("gcp"),
+									},
+								},
+							},
+						},
+					},
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "creds-provider", Ttl: durationpb.New(response.DefaultTTL)},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR"}`),
+						},
+						Resources: map[string]*fnv1.Resource{
+							"creds": {
+								Resource: resource.MustStructJSON(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"creds"},"data":{"provider":"gcp","url":"gcr.io/my-project"}}`),
+							},
+						},
+					},
+				},
+			},
+		},
 		"CustomCompositionResourceNameIsSet": {
 			reason: "The Function should set value of crossplane.io/composition-resource-name annotation by krm.kcl.dev/composition-resource-name annotation ",
 			args: args{

--- a/input/v1alpha1/input.go
+++ b/input/v1alpha1/input.go
@@ -112,9 +112,28 @@ type ConfigSpec struct {
 
 // CredSpec defines authentication credentials for remote locations
 type CredSpec struct {
-	Url      string `json:"url,omitempty" yaml:"url,omitempty"`
-	Username string `json:"username" yaml:"username"`
-	Password string `json:"password" yaml:"password"`
+	// +optional
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
+	// Username is required when provider is "basic" (the default).
+	// Ignored when provider is "gcp".
+	// +optional
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	// Password is required when provider is "basic" (the default).
+	// Ignored when provider is "gcp".
+	// +optional
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	// Provider selects the credential provider used to mint an OCI
+	// credential for `url`. The empty string and "basic" both use
+	// Username/Password directly via `kpm login`. "gcp" mints an
+	// OAuth2 access token from the GCE/GKE metadata server (Workload
+	// Identity Federation) and requires neither Username nor Password
+	// to be set — useful for GKE pods that should pull from Artifact
+	// Registry without any static credential.
+	//
+	// Crossplane users supply this via the `kcl-registry`
+	// OpaqueCredential's `provider` data field.
+	// +optional
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
 }
 
 type ResourceList []Resource

--- a/package/input/krm.kcl.dev_kclinputs.yaml
+++ b/package/input/krm.kcl.dev_kclinputs.yaml
@@ -96,13 +96,23 @@ spec:
                 properties:
                   password:
                     type: string
+                  provider:
+                    description: |-
+                      Provider selects the credential provider used to mint an OCI
+                      credential for `url`. The empty string and "basic" both use
+                      Username/Password directly via `kpm login`. "gcp" mints an
+                      OAuth2 access token from the GCE/GKE metadata server (Workload
+                      Identity Federation) and requires neither Username nor Password
+                      to be set — useful for GKE pods that should pull from Artifact
+                      Registry without any static credential.
+
+                      Crossplane users supply this via the `kcl-registry`
+                      OpaqueCredential's `provider` data field.
+                    type: string
                   url:
                     type: string
                   username:
                     type: string
-                required:
-                - password
-                - username
                 type: object
               dependencies:
                 description: |-


### PR DESCRIPTION
## Summary

Adds a `provider` field to `KCLInput.Spec.Credentials` so users can opt into
passwordless OCI pulls from inside a Crossplane Composition. When
`provider: "gcp"` is set, neither username nor password is required — the
credential is minted by kpm from the GCE/GKE metadata server
(Workload Identity Federation).

This is the function-kcl side of the work that started in
[kcl-lang/kpm#766](https://github.com/kcl-lang/kpm/pull/766) (the kpm provider
abstraction + GCP provider). kpm is the layer that actually authenticates
against the OCI registry; function-kcl only needs to forward the user's
choice through to it.

## Why

Closes #251. Today's `Credentials` schema makes `username`+`password`
mandatory, which forces users to distribute long-lived secrets to the
function pod — even when the cluster already has Workload Identity bound to
the pod's Kubernetes ServiceAccount.

## Behaviour change

- New optional field: `spec.credentials.provider` (string, default empty).
  Empty / `"basic"` keeps today's behaviour.
- `username` and `password` are now `+optional` so a provider-only
  credential validates cleanly.
- When the kpm side ships `gcp`, users can write:

  ```yaml
  apiVersion: krm.kcl.dev/v1alpha1
  kind: KCLInput
  spec:
    source: oci://gcr.io/my-project/my-module?tag=0.2.0
    credentials:
      url: https://gcr.io
      provider: gcp
  ```

  No `username` / `password` required, no `imagePullSecrets` required, and
  no Secret to mount into the function pod.

## Test plan

- [x] `go test ./...` — added `CredentialsProviderFlowsThrough` in
      `fn_test.go` to confirm the provider field is read out of the
      `kcl-registry` opaque credential and surfaced in
      `option("resource_list")?.functionConfig?.spec?.credentials`.
- [ ] Manual verification on a GKE cluster with Workload Identity bound to
      the function pod (depends on kpm#766 being merged and a new
      `crossplane-contrib/function-kcl` image being published that picks up
      the kpm change). Tracked in #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)